### PR TITLE
[RAPPS-DB] Add TortoiseGit 1.8.16.0

### DIFF
--- a/tgit.txt
+++ b/tgit.txt
@@ -1,0 +1,16 @@
+[Section]
+Name = TortoiseGit
+Version = 1.8.16.0
+License = GPL
+Description = Graphical shell interface to Git, based on TortoiseSVN, for code synchronization/updating.
+Size = 15.6 MiB
+Category = 7
+URLSite = https://tortoisegit.org/
+URLDownload = https://download.tortoisegit.org/tgit/1.8.16.0/TortoiseGit-1.8.16.0-32bit.msi
+SHA1 = ef5af7bb8eaa68bcb1dffd17b4cad23564169271
+CDPath = none
+SizeBytes = 16433152
+
+[Section.040c]
+Description = Interface graphique de shell pour Git, basée sur TortoiseSVN.
+Size = 15,6 Mio


### PR DESCRIPTION
It works great! And it's the last version that can work on Windows XP/2k3/ReactOS.