### PR TITLE
Add iQPuzzle to rapps

### DIFF
--- a/iqpuzzle.txt
+++ b/iqpuzzle.txt
@@ -1,0 +1,17 @@
+[Section]
+Name = iQPuzzle
+Version = 1.1.1
+License = Open Source (GPLv3)
+Description = A diverting I.Q. challenging pentomino puzzle
+Size = 22.8 MiB
+Category = 4
+URLSite = https://elth0r0.github.io/iqpuzzle/
+URLDownload = https://github.com/ElTh0r0/iqpuzzle/releases/download/v1.1.1/iQPuzzle-1.1.1-ReactOS_Installer.exe
+SHA1 = 728ead626903ef58192cdae856624e005ed450db
+CDPath = none
+SizeBytes = 24003230
+
+[Section.0407]
+Description = Ein kurzweiliges herausforderndes Pentomino-Puzzle
+Size = 22.8 MiB
+


### PR DESCRIPTION
Hi
iQPuzzle is a little puzzle game with more than 300 boards to be filled with pentomino pieces. It is based on Qt5 and running fine in ReactOS - tested with v0.4.8 (attached screenshot is from a German ReactOS installation, but the game includes English, French, Dutch and Bulgarien translation as well).

![iqpuzzle_reactos](https://user-images.githubusercontent.com/26674558/43039601-eebba95e-8d30-11e8-8333-bc2a477d399d.jpeg)

