### PR TITLE
[RAPPS-DB] Add Microsoft DirectX Feb 2010 Redistributable

### DIFF
--- a/directxfeb2010.txt
+++ b/directxfeb2010.txt
@@ -1,0 +1,32 @@
+[Section]
+Name = DirectX End-User Runtimes (Feb 2010) 
+Version = 9.28
+License = Unknown
+Description = Provides the runtimes required by most DirectX based applications and games. You have to manually run the installer after unpacking.
+Size = 104 MiB
+Category = 14
+URLSite = https://www.microsoft.com/en-us/download/details.aspx?id=9033
+URLDownload = https://download.microsoft.com/download/E/E/1/EE17FF74-6C45-4575-9CF4-7FC2597ACD18/directx_feb2010_redist.exe
+SHA1 = a97c820915dc20929e84b49646ec275760012a42
+CDPath = none
+SizeBytes = 109072752
+
+[Section.0415]
+License = Nieznana
+Description = Zawiera biblioteki wymagane przez większość gier i aplikacji opartych na DirectX. Należy uruchomić instalator po wypakowaniu plików.
+Size = 104 MiB
+
+[Section.0419]
+License = Неизвестно
+Description = Предоставляет библиотеки, необходимые для большинства приложений и игр, основаных на DirectX. Вам нужно запустить установщик вручную после распаковки.
+Size = 104 МиБ
+
+[Section.0422]
+License = Невідома
+Description = Надає бібліотеки, необхідні для більшості програм та ігор, заснованих на DirectX. Вам потрібно власноруч запустити інсталятор після розпакування.
+Size = 104 Міб
+
+[Section.0425]
+License = Tundmatu
+Description = Annab enamus DirectX põhinevate rakenduste ja mängude jaoks sobivad runtimed. Peate installeri käivitama käsitisi pärast lahti pakkimist.
+Size = 104 MiB


### PR DESCRIPTION
![directx_feb2010](https://user-images.githubusercontent.com/26385117/58838705-1c3d2200-8668-11e9-8c90-faa146da4945.png)
This version of DirectX is a bit older than June 2010 version, but it's more full: it also contains all other DirectX dlls besides d3dx9_xx.dll, Xaudio and Xinput (e.g. DirectInput, DirectMusic, DirectSound, DirectPlay etc.; they are stored in BDAXP.cab and dxnt.cab archives and are able to be installed via inf files). And it installs fine in ReactOS. So I think there is a reason to add it in Rapps.