### PR TITLE
[RAPPS-DB] Use a download link for snes9x that we can actually fetch

### DIFF
--- a/SNES9x.txt
+++ b/SNES9x.txt
@@ -5,8 +5,8 @@ License = GPL
 Description = a portable, freeware Super Nintendo Entertainment System (SNES) emulator. You'll need to change the video renderer to OpenGL in the video settings or in the ini file.
 Size = 2.61 MiB
 Category = 4
-URLSite = http://www.snes9x.com/
-URLDownload = https://sites.google.com/site/bearoso/snes9x/snes9x-1.60-win32.zip?attredirects=0&d=1
+URLSite = https://github.com/snes9xgit/snes9x/
+URLDownload = https://github.com/snes9xgit/snes9x/releases/download/1.60/snes9x-1.60-win32.zip
 SHA1 = a67156f159405c73be86df49818f9984dfee218d
 CDPath = none
 SizeBytes = 2619607


### PR DESCRIPTION
Currently trying to download this app results in the download screen being closed and no file being downloaded, so I'm, assuming RAPPS doesn't like downloading from google sites, instead let's download it from github and also link to it as the website since it'll always be the most updated