### PR TITLE
Fix xbgpack1.txt Download URL and Category

### DIFF
--- a/xbgpack1.txt
+++ b/xbgpack1.txt
@@ -4,9 +4,9 @@ Version = 1
 License = CC0
 Description = Super Mario 64 based backgrounds for ReactOS. 1024x1024 each.
 Size = 7.36 MB
-Category = 15
+Category = 16
 URLSite = https://xcallono.cf
-URLDownload = https://www.dropbox.com/s/ow467t0piyzfdgi/Mario%2064%20Backgrounds.zip?dl=1
+URLDownload = https://tinyurl.com/yy9dwry6
 SHA1 = 13385B2AD4794855CCC4AED0189FE8E943BE23C8
 CDPath = none
 SizeBytes = 7721027


### PR DESCRIPTION
@katahiromz Simple fix for the Download URL And put it in 'others' category and not Themes category. 