### PR TITLE
Update npp.txt

### DIFF
--- a/npp.txt
+++ b/npp.txt
@@ -1,6 +1,6 @@
 [Section]
 Name = Notepad++
-Version = 6.9.2
+Version = 6.9
 License = GPL
 Description = A full featured, free text editor with many plug-ins.
 Size = 4.0 MiB

--- a/npp.txt
+++ b/npp.txt
@@ -6,10 +6,10 @@ Description = A full featured, free text editor with many plug-ins.
 Size = 4.0 MiB
 Category = 6
 URLSite = http://notepad-plus-plus.org/
-URLDownload = https://notepad-plus-plus.org/repository/6.x/6.9.2/npp.6.9.2.Installer.exe
-SHA1 = 6a54e0e8c8dbfca68abe3cbe66d99c66ced59cea
+URLDownload = https://notepad-plus-plus.org/repository/6.x/6.9/npp.6.9.Installer.exe
+SHA1 = 99d3507a8eab110b7471bf2a8e63e88ecfb4e831
 CDPath = none
-SizeBytes = 4211112
+SizeBytes = 4206592
 
 [Section.0407]
 Description = Voll funktionsfähiger, kostenloser Texteditor mit vielen Plugins.


### PR DESCRIPTION
Updated link for notepad++ download.
Right now the link provided is not available. It causes the rapps to show an error message about download error.
I've updated it to version available on the notepad++ official website.