### PR TITLE
[RAPPS-DB] Add AssaultCube 1.2.0.2

### DIFF
--- a/assaultcube.txt
+++ b/assaultcube.txt
@@ -1,0 +1,22 @@
+[Section]
+Name = AssaultCube
+Version = 1.2.0.2
+License = Freeware
+Description = 3D first-person shooter based on Cube engine.
+Size = 43.3 MiB
+Category = 4
+URLSite = https://assault.cubers.net/
+URLDownload = https://github.com/assaultcube/AC/releases/download/v1.2.0.2/AssaultCube_v1.2.0.2.exe
+SHA1 = 91de3526daa12a139f051dee9f865f84be79aeed
+CDPath = none
+SizeBytes = 45464090
+
+[Section.0419]
+License = Бесплатно
+Description = Трехмерный шутер от первого лица, основанный на движке Cube.
+Size = 43,3 МиБ
+
+[Section.0422]
+License = Безкоштовно
+Description = Трьохмірний шутер від першої особи, що базується на движку Cube.
+Size = 43,3 МіБ


### PR DESCRIPTION
![assaultcube](https://user-images.githubusercontent.com/26385117/76787999-c387e180-67c2-11ea-9efc-495bde93faad.png)

AssaultCube is a free 3D first-person shooter game based on Cube engine.
Works fine in ReactOS, with Mesa3D from Rapps and with VBoxOGL renderer. Although with Mesa3D it has some minor issues: the map at the top right does not render properly (is invisible) and the game has lower FPS than with VBoxOGL.
I guess these are Mesa3D issues, not ReactOS, and on XP/2003 it will show same (or, at least, similar) result, although I did not test it yet.