### PR TITLE
[ADDITION] JET40 and MDAC28SP1

### DIFF
--- a/jet40.txt
+++ b/jet40.txt
@@ -2,8 +2,7 @@
 Name = Jet 4.0 Service Pack 8 (SP8) (KB829558) for 9x/NT
 Version = 4.0.7328
 License = Unknown
-Description = This installation includes Microsoft products that incorporate Microsoft Jet database engine version 4.0. 
-Size = 3.7 MiB
+Description = This installation includes Microsoft products that incorporate Microsoft Jet database engine version 4.0.
 Category = 14
 URLSite = https://www.microsoft.com/en-US/download/details.aspx?id=7151
 URLDownload = https://download.microsoft.com/download/4/3/9/4393c9ac-e69e-458d-9f6d-2fe191c51469/Jet40SP8_9xNT.exe

--- a/jet40.txt
+++ b/jet40.txt
@@ -1,0 +1,18 @@
+[Section]
+Name = Jet 4.0 Service Pack 8 (SP8) (KB829558) for 9x/NT
+Version = 4.0.7328
+License = Unknown
+Description = This installation includes Microsoft products that incorporate Microsoft Jet database engine version 4.0. 
+Size = 3.7 MiB
+Category = 14
+URLSite = https://www.microsoft.com/en-US/download/details.aspx?id=7151
+URLDownload = https://download.microsoft.com/download/4/3/9/4393c9ac-e69e-458d-9f6d-2fe191c51469/Jet40SP8_9xNT.exe
+SHA1 = 8cd25342030857969ede2d8fcc34f3f7bcc2d6d4
+CDPath = none
+SizeBytes = 3872168
+
+[Section.0a]
+Name = Jet 4.0 Service Pack 8 (SP8) (KB829558)
+License = Desconocida
+Description = Esta instalación incluye productos de Microsoft que incorporan funciones de Microsoft Jet database engine versión 4.0. 
+

--- a/jet40.txt
+++ b/jet40.txt
@@ -12,7 +12,7 @@ CDPath = none
 SizeBytes = 3872168
 
 [Section.0a]
-Name = Jet 4.0 Service Pack 8 (SP8) (KB829558)
+Name = Jet 4.0 Service Pack 8 (SP8) (KB829558) para 9x/NT
 License = Desconocida
 Description = Esta instalación incluye productos de Microsoft que incorporan funciones de Microsoft Jet database engine versión 4.0. 
 

--- a/mdac28.txt
+++ b/mdac28.txt
@@ -1,0 +1,16 @@
+[Section]
+Name =  Microsoft Data Access Components (MDAC) 2.8 SP1
+Version = 1.0
+License = Unknown
+Description = MDAC 2.8 SP1 contains core Data Access components such as the Microsoft SQL Server™ OLE DB provider and ODBC driver.
+Size = 5.8 MiB
+Category = 14
+URLSite = https://www.microsoft.com/en-us/download/details.aspx?id=5793
+URLDownload = https://download.microsoft.com/download/4/a/a/4aafff19-9d21-4d35-ae81-02c48dcbbbff/MDAC_TYP.EXE
+SHA1 = 4fbc272c79da59e38818924d8575accb0af776fb
+CDPath = none
+SizeBytes = 6100504
+
+[Section.0a]
+Description = MDAC 2.8 SP1 contiene el núcleo de componentes de Data Access como el Microsoft SQL Server™ OLE DB proveedor y driver ODBC.
+

--- a/mdac28.txt
+++ b/mdac28.txt
@@ -3,7 +3,6 @@ Name =  Microsoft Data Access Components (MDAC) 2.8 SP1
 Version = 1.0
 License = Unknown
 Description = MDAC 2.8 SP1 contains core Data Access components such as the Microsoft SQL Server™ OLE DB provider and ODBC driver.
-Size = 5.8 MiB
 Category = 14
 URLSite = https://www.microsoft.com/en-us/download/details.aspx?id=5793
 URLDownload = https://download.microsoft.com/download/4/a/a/4aafff19-9d21-4d35-ae81-02c48dcbbbff/MDAC_TYP.EXE


### PR DESCRIPTION
I want to add those two Microsoft libraries.
* JET 40 - I added the only JET compatible afaik (I tried the 2003 server and the WinMe ones).
* MDAC28SP1 - I added, you have to put this instalator in Windows 2000 mode to run it, two times and it installs.