### PR TITLE
[RAPPS-DB] Update VLC to version 3.0.10

### DIFF
--- a/vlc.txt
+++ b/vlc.txt
@@ -1,26 +1,26 @@
 [Section]
 Name = VLC media player
-Version = 3.0.7.1
+Version = 3.0.10
 License = GPL
 Description = A fully featured FOSS media player with built-in codecs.
-Size = 38.8 MiB
+Size = 39.3 MiB
 Category = 2
 URLSite = http://www.videolan.org/vlc/
-URLDownload = https://ftp.icm.edu.pl/pub/video/vlc/vlc/3.0.7.1/win32/vlc-3.0.7.1-win32.exe
-SHA1 = 23ed9eaf6e82596964f2a2c0eda141b5dcb4d14c
+URLDownload = https://ftp.icm.edu.pl/pub/video/vlc/vlc/3.0.10/win32/vlc-3.0.10-win32.exe
+SHA1 = 7b36da6307481baf90b664e44ba79747ef12fa90
 CDPath = none
-SizeBytes = 40693760
+SizeBytes = 41210600
 
 [Section.0407]
 Description = Voll funktionsfähiger FOSS Media-Player mit eingebauten Codecs.
-Size = 38,8 MiB
+Size = 39,3 MiB
 
 [Section.0a]
 Description = Completo reproductor multimedia, de código abierto y con códecs propios.
 
 [Section.040c]
 Description = Un lecteur media.
-Size = 38,8 Mio
+Size = 39,3 Mio
 
 [Section.0410]
 Description = Lettore multimediale.
@@ -33,11 +33,11 @@ Description = W pełni funkcjonalny, otwartoźródłowy odtwarzacz multimediów 
 
 [Section.0418]
 Description = Lector multimedia complet, gratuit cu surse deschise și codecuri încorporate.
-Size = 38,8 Mio
+Size = 39,3 Mio
 
 [Section.0419]
 Description = Мультимедийный проигрыватель.
-Size = 38,8 МиБ
+Size = 39,3 МиБ
 
 [Section.041b]
 Description = Multimediálny prehrávač.
@@ -45,7 +45,7 @@ Description = Multimediálny prehrávač.
 [Section.041f]
 Name = VLC Ortam Oynatıcısı
 Description = İçindeki kodeklerle tam özellikli bir FOSS ortam oynatıcısı.
-Size = 38,8 MiB
+Size = 39,3 MiB
 
 [Section.0422]
 Description = Мультимедійний програвач.

--- a/vlc.txt
+++ b/vlc.txt
@@ -3,7 +3,6 @@ Name = VLC media player
 Version = 3.0.10
 License = GPL
 Description = A fully featured FOSS media player with built-in codecs.
-Size = 39.3 MiB
 Category = 2
 URLSite = http://www.videolan.org/vlc/
 URLDownload = https://ftp.icm.edu.pl/pub/video/vlc/vlc/3.0.10/win32/vlc-3.0.10-win32.exe
@@ -13,14 +12,12 @@ SizeBytes = 41210600
 
 [Section.0407]
 Description = Voll funktionsfähiger FOSS Media-Player mit eingebauten Codecs.
-Size = 39,3 MiB
 
 [Section.0a]
 Description = Completo reproductor multimedia, de código abierto y con códecs propios.
 
 [Section.040c]
 Description = Un lecteur media.
-Size = 39,3 Mio
 
 [Section.0410]
 Description = Lettore multimediale.
@@ -33,11 +30,9 @@ Description = W pełni funkcjonalny, otwartoźródłowy odtwarzacz multimediów 
 
 [Section.0418]
 Description = Lector multimedia complet, gratuit cu surse deschise și codecuri încorporate.
-Size = 39,3 Mio
 
 [Section.0419]
 Description = Мультимедийный проигрыватель.
-Size = 39,3 МиБ
 
 [Section.041b]
 Description = Multimediálny prehrávač.
@@ -45,7 +40,6 @@ Description = Multimediálny prehrávač.
 [Section.041f]
 Name = VLC Ortam Oynatıcısı
 Description = İçindeki kodeklerle tam özellikli bir FOSS ortam oynatıcısı.
-Size = 39,3 MiB
 
 [Section.0422]
 Description = Мультимедійний програвач.


### PR DESCRIPTION
I tested out the Latest Version Available For VLC (3.0.10) and it works just fine. Audio playback works, Video playback works, Fullscreen mode works too (toolbar is still visible though). Purpose of this pull request is just to upgrade it from 3.0.7.1 to 3.0.10.
Tested on VirtualBox Version 6.1.8 r137981 (Qt5.6.2)
![VirtualBox_ReactOS_02_06_2020_17_23_44](https://user-images.githubusercontent.com/62068860/83525350-e8ecd780-a4f5-11ea-8f24-47f8da14a384.png)
