### PR TITLE
Version bump of VLC Media Player to 3.0.11

### DIFF
--- a/vlc.txt
+++ b/vlc.txt
@@ -1,14 +1,14 @@
 [Section]
 Name = VLC media player
-Version = 3.0.10
+Version = 3.0.11
 License = GPL
 Description = A fully featured FOSS media player with built-in codecs.
 Category = 2
 URLSite = http://www.videolan.org/vlc/
-URLDownload = https://ftp.icm.edu.pl/pub/video/vlc/vlc/3.0.10/win32/vlc-3.0.10-win32.exe
-SHA1 = 7b36da6307481baf90b664e44ba79747ef12fa90
+URLDownload = https://ftp.icm.edu.pl/pub/video/vlc/vlc/3.0.11/win32/vlc-3.0.11-win32.exe
+SHA1 = cf3b8ed243803c47a20c990174d8a42fa2e5789a
 CDPath = none
-SizeBytes = 41210600
+SizeBytes = 40732864
 
 [Section.0407]
 Description = Voll funktionsfähiger FOSS Media-Player mit eingebauten Codecs.


### PR DESCRIPTION
It installs and updates over 3.0.10 nicely on ReactOS 0.4.14 RC and 0.4.15-dev-latest
Link, size, and hash updated. don't think there's anything more needed.