### PR TITLE
[QTEMU] fix categories

### DIFF
--- a/QtEmu.txt
+++ b/QtEmu.txt
@@ -3,7 +3,7 @@
  Version = 1.0.5
  License = GPLv2
  Description = QtEmu is a graphical user interface for QEMU written in Qt4.
- Category = 15
+ Category = 16
  URLSite = https://qtemu.org/
  URLDownload = https://downloads.sourceforge.net/project/qtemu/qtemu/1.0.5/qtemu-1.0.5.exe
  SHA1 = 064318f1c199340fd08c5e314347f5a93460dc83


### PR DESCRIPTION
found when i want to download a theme, but qtemu is included in 'themes' category.
so, i shall move this qtemu category to 'others' to avoid confusion,