### PR TITLE
Change .NET Framework URLs to Internet Archive where possible

### DIFF
--- a/net11.txt
+++ b/net11.txt
@@ -6,7 +6,7 @@ Description = Components needed to run managed Windows applications compiled in 
 Size = 23.1 MiB
 Category = 14
 URLSite = http://www.microsoft.com/en-US/download/details.aspx?id=26
-URLDownload = http://download.microsoft.com/download/a/a/c/aac39226-8825-44ce-90e3-bf8203e74006/dotnetfx.exe
+URLDownload = https://web.archive.org/web/20210505032023if_/http://download.microsoft.com/download/a/a/c/aac39226-8825-44ce-90e3-bf8203e74006/dotnetfx.exe
 SHA1 = 16a354a2207c4c8846b617cbc78f7b7c1856340e
 CDPath = none
 SizeBytes = 24265736

--- a/net20.txt
+++ b/net20.txt
@@ -6,7 +6,7 @@ Description = Components needed to run managed Windows applications compiled in 
 Size = 22.4 MiB
 Category = 14
 URLSite = http://www.microsoft.com/downloads/details.aspx?FamilyID=0856eacb-4362-4b0d-8edd-aab15c5e04f5
-URLDownload = http://download.microsoft.com/download/5/6/7/567758a3-759e-473e-bf8f-52154438565a/dotnetfx.exe
+URLDownload = https://web.archive.org/web/20210505034809if_/http://download.microsoft.com/download/5/6/7/567758a3-759e-473e-bf8f-52154438565a/dotnetfx.exe
 SHA1 = a3625c59d7a2995fb60877b5f5324892a1693b2a
 CDPath = none
 SizeBytes = 23510720
@@ -47,4 +47,3 @@ Size = 22,4 MiB
 [Section.0804]
 License = 未知
 Description = 运行由 C# 之类所编译成中间语言所组成的托管 Windows 应用程序所需的组件。
-

--- a/net20sp2.txt
+++ b/net20sp2.txt
@@ -6,7 +6,7 @@ Description = Components needed to run managed Windows applications compiled in 
 Size = 23.8 MiB
 Category = 14
 URLSite = http://www.microsoft.com/en-US/download/details.aspx?id=1639
-URLDownload = http://download.microsoft.com/download/c/6/e/c6e88215-0178-4c6c-b5f3-158ff77b1f38/NetFx20SP2_x86.exe
+URLDownload = https://web.archive.org/web/20190523030127if_/http://download.microsoft.com/download/c/6/e/c6e88215-0178-4c6c-b5f3-158ff77b1f38/NetFx20SP2_x86.exe
 SHA1 = 22d776d4d204863105a5db99e8b8888be23c61a7
 CDPath = none
 SizeBytes = 25001480

--- a/net40.txt
+++ b/net40.txt
@@ -6,7 +6,7 @@ Description = Components needed to run managed Windows applications compiled in 
 Size = 48.1 MiB
 Category = 14
 URLSite = http://www.microsoft.com/en-US/download/details.aspx?id=17718
-URLDownload = https://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe
+URLDownload = https://web.archive.org/web/20210525175036if_/https://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe
 SHA1 = 58da3d74db353aad03588cbb5cea8234166d8b99
 CDPath = none
 SizeBytes = 50449456
@@ -54,4 +54,3 @@ Size = 48,1 MiB
 License = 未知
 Description = 运行由 C# 之类所编译成中间语言所组成的托管 Windows 应用程序所需的组件。
 URLSite = https://www.microsoft.com/zh-CN/download/details.aspx?id=1639
-


### PR DESCRIPTION
.NET Framework 1.1 and 2.0SP2 can no longer be downloaded, so I removed their entries instead. [CORE-17555](https://jira.reactos.org/browse/CORE-17555)