### PR TITLE
[RAPPS-DB] Update Audacious to version 3.10.1

### DIFF
--- a/audacious.txt
+++ b/audacious.txt
@@ -1,15 +1,15 @@
 [Section]
 Name = Audacious
-Version = 3.5.2
+Version = 3.10.1
 License = BSD
 Description = An open source audio player inspired by Winamp/XMMS.
 Category = 1
 URLSite = https://audacious-media-player.org/
-URLDownload = https://distfiles.audacious-media-player.org/audacious-3.5.2-win32.zip
-SHA1 = 6b44de048a61c9356ba1a4aec1642c0b47a1bd9b
-SizeBytes = 19331247
+URLDownload = https://distfiles.audacious-media-player.org/audacious-3.10.1-win32.exe
+SHA1 = 988f86765b77315e6ccbc3bd53b78cc08fbed501
+SizeBytes = 15969876
 Icon = audacious.ico
-Screenshot1 = https://i.imgur.com/iGmnYJV.png
+Screenshot1 = https://i.imgur.com/xpvdELX.png
 
 [Section.0419]
 Description = Аудиопроигрыватель с открытым исходным кодом, вдохновлённый Winamp/XMMS.


### PR DESCRIPTION
Update Audacious media player to version 3.10.1. This is the last version which supports XP/2003.
It works without any issues after recent user32/win32k fixes those fixed all other GTK+ apps (so some of them can also be updated as well). And it has no any graphical glitches at all, unlike previous 3.5.2 version. :slightly_smiling_face: 
![audacious-fixed](https://user-images.githubusercontent.com/26385117/142768928-1d081299-785a-49e5-b282-b7441773cd57.png)

- Update version number.
- Update the download URL (now it points to an executable installer instead of just zip archive).
- Update SHA1 sum of the installer.
- Update size in bytes, of the installer.
- Update the app's screenshot (now version 3.10.1 is displayed there).