### PR TITLE
[RAPPS-DB] Add Krita 3.2.1 to x86 and x64

### DIFF
--- a/krita.txt
+++ b/krita.txt
@@ -2,7 +2,7 @@
 Name = Krita
 Version = 3.2.1
 License = GPL
-Description = Krita is an open-source graphic editor that allows to draw, paint and make 2D animation. Is based in KDE.
+Description = Krita is an open-source graphic editor that allows to draw, paint and make 2D animation. Is a part of KDE.
 Category = 3
 URLSite = https://krita.org
 URLDownload = https://download.kde.org/Attic/krita/3.2.1/krita-3.2.1-x86.zip

--- a/krita.txt
+++ b/krita.txt
@@ -1,0 +1,19 @@
+[Section]
+Name = Krita
+Version = 3.2.1
+License = GPL
+Description = Krita is an open-source graphic editor that allows to draw, paint and make 2D animation. Is based in KDE.
+Category = 3
+URLSite = https://krita.org
+URLDownload = https://download.kde.org/Attic/krita/3.2.1/krita-3.2.1-x86.zip
+SHA1 = 3f3ff0c2d971b8803fa978efd59f65aa7f8e8f1f
+SizeBytes = 71598080
+
+[Section.amd64]
+Version = 3.2.1
+URLDownload = https://download.kde.org/Attic/krita/3.2.1/krita-3.2.1-x64.zip
+SHA1 = cb85d630a8efdbc816296d757e05b1dc3d77943d
+SizeBytes = 100532224
+
+[Section.0a]
+Description = Krita es un programa de edición de imagen open source, que te permite dibujar, pintar y hacer animación 3D. Está basado en KDE.

--- a/krita.txt
+++ b/krita.txt
@@ -16,4 +16,4 @@ SHA1 = cb85d630a8efdbc816296d757e05b1dc3d77943d
 SizeBytes = 100532224
 
 [Section.0a]
-Description = Krita es un programa de edición de imagen open source, que te permite dibujar, pintar y hacer animación 3D. Está basado en KDE.
+Description = Krita es un programa de edición de imagen open source, que te permite dibujar, pintar y hacer animación 3D. Es parte de KDE.


### PR DESCRIPTION
Let's send this PR to sync with the ReactOS compatible Krita 3.2.1, last Windows XP compatible version. It's working nice. In the x64 version, have some font bug, that will be solved for sure in the near future. I will attach screenshots from other navigator if it allows me to do it, because Palemoon in ReactOS is not attaching the files in github.com xD

Edit: It doesn't need shims (in my experience) in Windows XP x64. However, if it does need any shim, lately could be applied (same that suffers the MDAC package). Screenshots of use without applying any shim (Luna theme :P).


![Krita1](https://user-images.githubusercontent.com/27921286/201615587-34796a87-87ec-44e4-98ab-af21127d8ef0.png)
![Krita2](https://user-images.githubusercontent.com/27921286/201615593-ce377314-3fb6-4899-b658-3df3bc76c6be.png)
![Krita3](https://user-images.githubusercontent.com/27921286/201615597-dbeced9e-154e-4152-8d47-d590c2a82e47.png)

x64 screenshots about testing the software under ReactOS x64 (crt solved):

![krita fixed 1](https://user-images.githubusercontent.com/27921286/201615865-f3f5e854-e290-4f7c-a4ab-88b833608117.png)
![krita fixed 2](https://user-images.githubusercontent.com/27921286/201615874-50475239-e8f9-477a-871e-876f52c0a5b7.png)
 
