### PR TITLE
Fix incorrect file size and hash for Dave Gnukem causing integrity check fail

### DIFF
--- a/davegnukem.txt
+++ b/davegnukem.txt
@@ -1,12 +1,12 @@
 [Section]
 Name = Dave Gnukem
-Version = 1.01
+Version = 1.0.1
 License = MIT GPL CC
 LicenseInfo = 1
 Description =  Dave Gnukem is a retro-style 2D scrolling platform shooter. It is inspired by and similar to Duke Nukem 1.
 Category = 4
 URLSite = https://github.com/davidjoffe/dave_gnukem
 URLDownload = https://sourceforge.net/projects/gnukem/files/gnukem/Dave_Gnukem_Setup_1.0.1.exe
-SHA1 = 1f0ebdeadb9aca427ad2ab14617103793506676f
-SizeBytes = 21524896
+SHA1 = f76044ac6b8d98e1039a860a820337dced01a8d1
+SizeBytes = 21527672
 Languages=0409


### PR DESCRIPTION
(Dave Gnukem creator here) - for reasons unclear to me that v1.0.1 sourceforge link, although it downloads the binary to the RAPPS download folder, says 'fails integrity check' in the ReactOS Application Manager now (SHA1 and filesize are different) ... I guess I may have replaced the v1.0.1 exe on sourceforge at some stage possibly with a slightly different version after release (don't recall now for 100% sure). This should be the correct file size and sha1 now.

(Note there's a newer version of Dave Gnukem 1.0.3.2 currently, however, that fails in ReactOS with a DLL-related runtime error so let's stick to v1.0.1 for now.)

*Edit* Looking at the digital signature, I can see the current 21527672-byte installer file was digitally signed by myself (Jan 2022), so it must be correct and this binary must be correct/valid.

@qbancoffee  @learn-more  (IIRC qbancoffee originally added this rapps-db entry for Dave Gnukem, and I think it did used to work, so likely I must have changed the binary at some stage, IIRC for something small - in theory this commit should get it working again)