### PR TITLE
[RAPPS-DB] Add Chromium-XP browsers 49.0.2623.113

### DIFF
--- a/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
+++ b/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
@@ -2,7 +2,7 @@
 Name = Chromium-XP
 Version = 49.0.2623.113-R2 VS2015 SSE2 2nd Release
 License = BSD 3-Clause
-Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run on ROS.
+Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run.
 Category = 5
 URLSite = https://github.com/Alex313031/chromium-xp
 URLDownload = https://github.com/Alex313031/chromium-xp/releases/download/M49.0.2623.113-2/mini_installer.exe

--- a/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
+++ b/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
@@ -1,0 +1,10 @@
+[Section]
+Name = Chromium-XP
+Version = 49.0.2623.113-R2 VS2015 SSE2 2nd Release
+License = BSD 3-Clause License
+Description = Prebundled with Pepperflash 21.0.0.213. WebM VP9 support. Currently needs --no-sandbox command line option to run on ros.
+Category = 5
+URLSite = https://github.com/Alex313031/chromium-xp
+URLDownload = https://github.com/Alex313031/chromium-xp/releases/download/M49.0.2623.113-2/mini_installer.exe
+SHA1 = 29fe5f8e02adfe44fe5bdbeb749fa93f97fc2aaf
+SizeBytes = 47201792

--- a/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
+++ b/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
@@ -1,6 +1,6 @@
 [Section]
 Name = Chromium-XP
-Version = 49.0.2623.113-R2 VS2015 SSE2 2nd Release
+Version = 49.0.2623.113-R2 VS2015 SSE2
 License = BSD 3-Clause
 Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run.
 Category = 5

--- a/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
+++ b/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
@@ -2,7 +2,7 @@
 Name = Chromium-XP
 Version = 49.0.2623.113-R2 VS2015 SSE2 2nd Release
 License = BSD 3-Clause License
-Description = Prebundled with Pepperflash 21.0.0.213. WebM VP9 support. Currently needs --no-sandbox command line option to run on ros.
+Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run on ros.
 Category = 5
 URLSite = https://github.com/Alex313031/chromium-xp
 URLDownload = https://github.com/Alex313031/chromium-xp/releases/download/M49.0.2623.113-2/mini_installer.exe

--- a/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
+++ b/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
@@ -1,7 +1,7 @@
 [Section]
 Name = Chromium-XP
 Version = 49.0.2623.113-R2 VS2015 SSE2 2nd Release
-License = BSD 3-Clause License
+License = BSD 3-Clause
 Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run on ROS.
 Category = 5
 URLSite = https://github.com/Alex313031/chromium-xp

--- a/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
+++ b/Chromium-XP_49_0_2623_113-R2_VS2015_SSE2.txt
@@ -2,7 +2,7 @@
 Name = Chromium-XP
 Version = 49.0.2623.113-R2 VS2015 SSE2 2nd Release
 License = BSD 3-Clause License
-Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run on ros.
+Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run on ROS.
 Category = 5
 URLSite = https://github.com/Alex313031/chromium-xp
 URLDownload = https://github.com/Alex313031/chromium-xp/releases/download/M49.0.2623.113-2/mini_installer.exe

--- a/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
+++ b/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
@@ -1,7 +1,7 @@
 [Section]
 Name = Chromium-XP
 Version = 49.0.2623.113 VS2013 SSE3 1st Release
-License = BSD 3-Clause License
+License = BSD 3-Clause
 Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run on ROS.
 Category = 5
 URLSite = https://github.com/Alex313031/chromium-xp

--- a/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
+++ b/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
@@ -2,7 +2,7 @@
 Name = Chromium-XP
 Version = 49.0.2623.113 VS2013 SSE3 1st Release
 License = BSD 3-Clause License
-Description = Prebundled with Pepperflash 21.0.0.213. WebM VP9 support. Currently needs --no-sandbox command line option to run on ros.
+Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run on ros.
 Category = 5
 URLSite = https://github.com/Alex313031/chromium-xp
 URLDownload = https://github.com/Alex313031/chromium-xp/releases/download/M49.0.2623.113/mini_installer_MSVS2013.exe

--- a/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
+++ b/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
@@ -2,7 +2,7 @@
 Name = Chromium-XP
 Version = 49.0.2623.113 VS2013 SSE3 1st Release
 License = BSD 3-Clause
-Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run on ROS.
+Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run.
 Category = 5
 URLSite = https://github.com/Alex313031/chromium-xp
 URLDownload = https://github.com/Alex313031/chromium-xp/releases/download/M49.0.2623.113/mini_installer_MSVS2013.exe

--- a/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
+++ b/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
@@ -1,6 +1,6 @@
 [Section]
 Name = Chromium-XP
-Version = 49.0.2623.113 VS2013 SSE3 1st Release
+Version = 49.0.2623.113 VS2013 SSE3
 License = BSD 3-Clause
 Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run.
 Category = 5

--- a/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
+++ b/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
@@ -1,0 +1,10 @@
+[Section]
+Name = Chromium-XP
+Version = 49.0.2623.113 VS2013 SSE3 1st Release
+License = BSD 3-Clause License
+Description = Prebundled with Pepperflash 21.0.0.213. WebM VP9 support. Currently needs --no-sandbox command line option to run on ros.
+Category = 5
+URLSite = https://github.com/Alex313031/chromium-xp
+URLDownload = https://github.com/Alex313031/chromium-xp/releases/download/M49.0.2623.113/mini_installer_MSVS2013.exe
+SHA1 = 17204758da42ea5e30f463392ff37368a6f3929e
+SizeBytes = 44779008

--- a/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
+++ b/Chromium-XP_49_0_2623_113_VS2013_SSE3.txt
@@ -2,7 +2,7 @@
 Name = Chromium-XP
 Version = 49.0.2623.113 VS2013 SSE3 1st Release
 License = BSD 3-Clause License
-Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run on ros.
+Description = Prebundled with Pepperflash 21.0.0.213. 489/555 in html5test.com. Currently needs --no-sandbox command line option to run on ROS.
 Category = 5
 URLSite = https://github.com/Alex313031/chromium-xp
 URLDownload = https://github.com/Alex313031/chromium-xp/releases/download/M49.0.2623.113/mini_installer_MSVS2013.exe


### PR DESCRIPTION
Prebundled with (outdated) Pepperflash 21.0.0.213.
489/555 points in html5test.com
WebM VP9 support.
Currently needs --no-sandbox command line option to run on ros (ros bug https://jira.reactos.org/browse/CORE-9272 ).
Currently suffers from the well-known "sticky-mouse-issue" in ros (ros bug https://jira.reactos.org/browse/CORE-14998 ).
Currently must be killed with the taskmgr to end its processes in ros (ros bug https://jira.reactos.org/browse/CORE-14185 ).
Currently quickly lures ros to BSOD 0x1A unless you spend a lot of RAM on it (>1GB highly recommended) (ros bug same callstack as https://jira.reactos.org/browse/CORE-18190 ).
**The browser runs without any quirks on 2k3sp2 and XPSP3.** It is well done, indeed outperforming the last official Chromium sources M49.0.2623.112.

Forked from the official Chromium sources M49.0.2623.112
![1](https://github.com/reactos/rapps-db/assets/33393466/58834be0-6855-4043-bf9a-d01a70a10f72)
![2](https://github.com/reactos/rapps-db/assets/33393466/c02b82fc-2467-481b-9d35-aeb40a5b4f0f)
![3outdatedPepperflash](https://github.com/reactos/rapps-db/assets/33393466/08d11e69-ca6e-4476-905a-8cdf3516ff53)
![4](https://github.com/reactos/rapps-db/assets/33393466/a14ff238-2d87-4ff9-8ed5-46150722d82c)
![5sourceforge_demo](https://github.com/reactos/rapps-db/assets/33393466/60aef9cf-4374-4f6b-b020-ed28b2738756)
![7](https://github.com/reactos/rapps-db/assets/33393466/cec56367-77e1-4641-a950-05fb9b6866ca)
