### PR TITLE
Replace LicenseInfo with LicenseType

### DIFF
--- a/.github/validate-rapps.py
+++ b/.github/validate-rapps.py
@@ -24,7 +24,7 @@ ALL_KEYS = [
     b'SizeBytes',
     b'Icon',
     b'Screenshot1',
-    b'LicenseInfo',
+    b'LicenseType',
     b'Languages',
 ]
 

--- a/armagetron.txt
+++ b/armagetron.txt
@@ -2,7 +2,7 @@
 Name = Armagetron Advanced
 Version = 0.2.9.0.1
 License = GPL
-LicenseInfo = 1
+LicenseType = 1
 Description =  A Tron clone in 3D. Full screen is laggy 640x480 works well.
 Category = 4
 URLSite = http://www.armagetronad.org/downloads.php

--- a/clamwin.txt
+++ b/clamwin.txt
@@ -2,7 +2,7 @@
 Name = ClamWin Free Antivirus
 Version = 0.103.2.1
 License = GPL
-LicenseInfo = 1
+LicenseType = 1
 Description = ClamWin is a Free Antivirus program for Microsoft Windows 10/8/7/Vista/XP/Me/2000/98 and Windows Server 2012, 2008 and 2003.
 Category = 12
 URLSite = http://www.clamwin.com/

--- a/davegnukem.txt
+++ b/davegnukem.txt
@@ -2,7 +2,7 @@
 Name = Dave Gnukem
 Version = 1.0.1
 License = MIT GPL CC
-LicenseInfo = 1
+LicenseType = 1
 Description =  Dave Gnukem is a retro-style 2D scrolling platform shooter. It is inspired by and similar to Duke Nukem 1.
 Category = 4
 URLSite = https://github.com/davidjoffe/dave_gnukem

--- a/iqpuzzle.txt
+++ b/iqpuzzle.txt
@@ -1,7 +1,8 @@
 [Section]
 Name = iQPuzzle
 Version = 1.2.9
-License = Open Source (GPLv3)
+License = GPLv3
+LicenseType = 1
 Description = A diverting I.Q. challenging pentomino puzzle
 Category = 4
 URLSite = https://elth0r0.github.io/iqpuzzle/

--- a/jdk8.txt
+++ b/jdk8.txt
@@ -2,7 +2,7 @@
 Name = Java SE 8. Compiler and Runtime Environment.
 Version = 8.48.0.53
 License = GPLv2
-LicenseInfo = 1
+LicenseType = 1
 Description =  An open source Java compiler and runtime environment built by Zulu based on OpenJDK.
 Category = 7
 URLSite = https://www.azul.com

--- a/lzdoom.txt
+++ b/lzdoom.txt
@@ -2,7 +2,7 @@
 Name = LZDoom and Freedoom packaged with an installer.
 Version = 3.86
 License = GPL and BSD
-LicenseInfo = 1
+LicenseType = 1
 Description =  Open source Doom assets packged with an open source Doom engine.
 Category = 4
 URLSite = https://sourceforge.net/projects/lzdoom-plus-freedoom

--- a/openoffice.txt
+++ b/openoffice.txt
@@ -2,7 +2,7 @@
 Name = Apache OpenOffice
 Version = 4.1.14
 License = AL v2.0
-LicenseInfo = 1
+LicenseType = 1
 Description = Open source office suite.
 Category = 6
 URLSite = https://www.openoffice.org/

--- a/stackandconquer.txt
+++ b/stackandconquer.txt
@@ -1,7 +1,8 @@
 [Section]
 Name = StackAndConquer
 Version = 0.10.0
-License = Open Source (GPLv3)
+License = GPLv3
+LicenseType = 1
 Description = A challenging tower conquest board game
 Category = 4
 URLSite = https://github.com/ElTh0r0/stackandconquer

--- a/winfile.txt
+++ b/winfile.txt
@@ -2,7 +2,7 @@
 Name = WinFile
 Version = 10.14.4.0
 License = MIT
-LicenseInfo = 1
+LicenseType = 1
 Description =  The Windows File Manager lives again and runs as a native x86 and x64 desktop app on all currently supported version of Windows, including Windows 10.
 Category = 12
 URLSite = https://github.com/qbancoffee/winfile/tree/reactos


### PR DESCRIPTION
LicenseInfo was always wrong, the name is LicenseType.

This fixes the DB entries related to [CORE-17771](https://jira.reactos.org/browse/CORE-17771).