### PR TITLE
Allow and use the RegName entry

### DIFF
--- a/.github/validate-rapps.py
+++ b/.github/validate-rapps.py
@@ -26,6 +26,7 @@ ALL_KEYS = [
     b'Screenshot1',
     b'LicenseType',
     b'Languages',
+    b'RegName',
 ]
 
 

--- a/dplus.txt
+++ b/dplus.txt
@@ -8,6 +8,7 @@ URLSite = http://dplus-browser.sourceforge.net/
 URLDownload = http://download.sourceforge.net/project/dplus-browser/Releases/dplus-0.5b/dplus-0.5b-setup.exe
 SHA1 = 26fa54b8fbe66e7172bdf217cce247f49f7d92e6
 SizeBytes = 1425497
+RegName = DPlus
 
 [Section.0a]
 Description = Un navegador de archivos con interfaz gráfica y un énfasis en la seguridad, el rendimiento y la portabilidad. Se basa en Dillo y es una versión alternativa del proyecto Dillo-Win32.

--- a/opera.txt
+++ b/opera.txt
@@ -8,6 +8,7 @@ URLSite = http://www.opera.com/
 URLDownload = https://web.archive.org/web/20210606230730/http://ftp.opera.com/pub/opera/win/1218/int/Opera_1218_int_Setup.exe
 SHA1 = b2344bfd13e85dab4f50c0b579b9a485bf473136
 SizeBytes = 12956472
+RegName = Opera 12.18.1872
 
 [Section.0a]
 Description = Popular navegador web con muchas características avanzadas, incluyendo un cliente de correo y BitTorrent.

--- a/opera9.txt
+++ b/opera9.txt
@@ -8,6 +8,7 @@ URLSite = http://www.opera.com/
 URLDownload = https://web.archive.org/web/20140327183619if_/http://arc.opera.com/pub/opera/win/964/int/Opera_964_int_Setup.exe
 SHA1 = e7354e79956acae6f76727a3c9bb3c25ea3a7b6f
 SizeBytes = 7562568
+RegName = {E1BBBAC5-2857-4155-82A6-54492CE88620}
 
 [Section.0a]
 Description = Popular navegador web con muchas características avanzadas, incluyendo un cliente de correo y BitTorrent.

--- a/reshack.txt
+++ b/reshack.txt
@@ -8,6 +8,7 @@ URLSite = http://www.angusj.com/resourcehacker/
 URLDownload = https://web.archive.org/web/20180426130124if_/http://www.angusj.com/resourcehacker/reshacker_setup.exe
 SHA1 = a34547ccb44ce387c95e97d540e4763894a4a15b
 SizeBytes = 2933617
+RegName = ResourceHacker_is1
 
 [Section.0a]
 Description = Una utilidad gratuita para ver, editar, renombrar, borrar y extraer recursos de ejecutables de Windows y archivos derivados (*.res).


### PR DESCRIPTION
Rapps already supports and uses the RegName entry when it tries to detect if an available application is already installed on the system. Rapps also tries to match based on the display name but that does not work for everything.

I added it to a couple of applications in this PR but there are probably more that need it but one would have to install every Rapps application first to find out.