### PR TITLE
[RAPPS-DB] Add 'ReactOS CJK Font' 1.3 (cjkfont)

### DIFF
--- a/cjkfont.txt
+++ b/cjkfont.txt
@@ -1,10 +1,10 @@
 [Section]
 Name = ReactOS CJK Font
-Version = 1.1
+Version = 1.2
 License = Apache License Version 2.0
 Description = The font package of ReactOS for CJK (Chinese, Japanese, and Korean) users. It contains "DroidSansFallback.ttf" font file.
 Category = 16
 URLSite = https://github.com/katahiromz/ReactOSCJKFont
-URLDownload = https://github.com/katahiromz/ReactOSCJKFont/releases/download/1.1/ReactOS-CJK-Font-1.1-setup.exe
-SHA1 = bde9e949bc1260f80c08b4bf558f3739beb57423
-SizeBytes = 1591087
+URLDownload = https://github.com/katahiromz/ReactOSCJKFont/releases/download/1.2/ReactOS-CJK-Font-1.2-setup.exe
+SHA1 = 45cb3052dc3d42cd948526e9f4e4e5e8aa878070
+SizeBytes = 1591100

--- a/cjkfont.txt
+++ b/cjkfont.txt
@@ -1,0 +1,10 @@
+[Section]
+Name = ReactOS CJK Font
+Version = 1.0
+License = Apache License Version 2.0
+Description = The font package of ReactOS for CJK (Chinese, Japanese, and Korean) users.
+Category = 16
+URLSite = https://github.com/katahiromz/ReactOSCJKFont
+URLDownload = https://github.com/katahiromz/ReactOSCJKFont/releases/download/1.0/ReactOS-CJK-Font-setup.exe
+SHA1 = 1046fc3fcbe5782fd087127074b9b9132ae95622
+SizeBytes = 1591087

--- a/cjkfont.txt
+++ b/cjkfont.txt
@@ -1,10 +1,10 @@
 [Section]
 Name = ReactOS CJK Font
-Version = 1.2
+Version = 1.3
 License = Apache License Version 2.0
 Description = The font package of ReactOS for CJK (Chinese, Japanese, and Korean) users. It contains "DroidSansFallback.ttf" font file.
 Category = 16
 URLSite = https://github.com/katahiromz/ReactOSCJKFont
-URLDownload = https://github.com/katahiromz/ReactOSCJKFont/releases/download/1.2/ReactOS-CJK-Font-1.2-setup.exe
-SHA1 = 45cb3052dc3d42cd948526e9f4e4e5e8aa878070
-SizeBytes = 1591100
+URLDownload = https://github.com/katahiromz/ReactOSCJKFont/releases/download/1.3/ReactOS-CJK-Font-1.3-setup.exe
+SHA1 = b9c7872e15c6f3d45e01ead831b907ae53b204fa
+SizeBytes = 1591124

--- a/cjkfont.txt
+++ b/cjkfont.txt
@@ -2,7 +2,7 @@
 Name = ReactOS CJK Font
 Version = 1.1
 License = Apache License Version 2.0
-Description = The font package of ReactOS for CJK (Chinese, Japanese, and Korean) users.
+Description = The font package of ReactOS for CJK (Chinese, Japanese, and Korean) users. It contains "DroidSansFallback.ttf" font file.
 Category = 16
 URLSite = https://github.com/katahiromz/ReactOSCJKFont
 URLDownload = https://github.com/katahiromz/ReactOSCJKFont/releases/download/1.1/ReactOS-CJK-Font-1.1-setup.exe

--- a/cjkfont.txt
+++ b/cjkfont.txt
@@ -1,10 +1,10 @@
 [Section]
 Name = ReactOS CJK Font
-Version = 1.0
+Version = 1.1
 License = Apache License Version 2.0
 Description = The font package of ReactOS for CJK (Chinese, Japanese, and Korean) users.
 Category = 16
 URLSite = https://github.com/katahiromz/ReactOSCJKFont
-URLDownload = https://github.com/katahiromz/ReactOSCJKFont/releases/download/1.0/ReactOS-CJK-Font-setup.exe
-SHA1 = 1046fc3fcbe5782fd087127074b9b9132ae95622
+URLDownload = https://github.com/katahiromz/ReactOSCJKFont/releases/download/1.1/ReactOS-CJK-Font-1.1-setup.exe
+SHA1 = bde9e949bc1260f80c08b4bf558f3739beb57423
 SizeBytes = 1591087


### PR DESCRIPTION
This PR will add "ReactOS CJK Font" package.

Screenshot:
![VirtualBox_ReactOS_24_10_2023_10_57_47](https://github.com/reactos/rapps-db/assets/2107452/93495f1a-d259-4b5f-a575-9af775b525fe)

See also: https://github.com/katahiromz/ReactOSCJKFont