### PR TITLE
[RAPPS-DB] Add Chicken Invaders 1 v1.30

### DIFF
--- a/chickeninvaders.txt
+++ b/chickeninvaders.txt
@@ -1,0 +1,10 @@
+[Section]
+Name = Chicken Invaders
+Version = 1.30
+License = Freeware
+Description = Earth is being invaded by chickens from another galaxy, bent on revenge against the human race for its oppression of earth chickens! You are the only one standing in the way of total annihilation of the human race! The future of chicken burgers is in your hands!
+Category = 4
+URLSite = https://www.interactionstudios.com/chickeninvaders.php
+URLDownload = https://archive.org/download/ChickenInvadersInstaller130/ChickenInvadersInstaller130.exe
+SHA1 = bc304efa49915e1f587b44c5c8894574b155cbf4
+SizeBytes = 3262255


### PR DESCRIPTION
A 2D space shooting game.

Version: 1.30
Offlicial site: [https://www.interactionstudios.com/chickeninvaders.php](https://www.interactionstudios.com/chickeninvaders.php)
License: Proprietary freeware, can freely distribute. (License included in the installation folder)

The latest version from official site included remastered edition which requires Windows 7+ and the download link for compatible version isn't available from both official site and Wayback Machine so I have to use the unofficial download link from [archive.org](https://archive.org/details/ChickenInvadersInstaller130).

Screenshot (tested on ReactOS 0.4.15-dev-7406):
![ROS_CI1](https://github.com/reactos/rapps-db/assets/86486978/84bd6557-4d41-418a-a70b-b0070e68c2f1)