### PR TITLE
[RAPPS-DB] Update the 7zip x64 version with the MSI setup

### DIFF
--- a/7zip.txt
+++ b/7zip.txt
@@ -11,10 +11,10 @@ SizeBytes = 1301195
 Icon = 7zip.ico
 
 [Section.amd64]
-Version = 19.00
-URLDownload = http://svn.reactos.org/packages/7z1900-x64.exe
-SHA1 = 0138746b529d4d3a81302c2bc355a0b855a86d38
-SizeBytes = 1594881
+Version = 23.01
+URLDownload = https://www.7-zip.org/a/7z2301-x64.msi
+SHA1 = bcfc5c64d9847f74ca41b94ad98f0b9eff0e2e93
+SizeBytes = 1933312
 
 [Section.0001]
 Description = .برنامج لضغط وفك ضغط الملفات يدعم تنسيقات متعددة مثل زيب و 7زيب و رار و غيرها


### PR DESCRIPTION
Contribute to the RAPPS-DB with the 7zip 23.01 setup available in the oficial website, that is x64 compatible. Works under our MSVC x64 and the GCC x64 (patched).

Also it set-up the context menu, registry entries and the shortcut better than our older "handmade" 19.00 7zip.

Showing up the setup:
![VirtualBox_ReactOS master_08_01_2024_20_51_40](https://github.com/reactos/rapps-db/assets/27921286/63973996-ec54-4693-a152-7f71134c7fdf)
![4](https://github.com/reactos/rapps-db/assets/27921286/5dfb9a6f-1b0f-4f28-bbc8-19d7b7655926)
![3](https://github.com/reactos/rapps-db/assets/27921286/1ad9c4f4-996a-4508-b21d-59e22397b024)

Doing an extraction:
![7](https://github.com/reactos/rapps-db/assets/27921286/50aa5bdf-e2a3-41fd-8c1c-e21db579e9d1)

GUI:
![8](https://github.com/reactos/rapps-db/assets/27921286/ac9b8914-8334-4f0e-8e8f-a576f781c167)