### PR TITLE
[RAPPS-DB] Add ReactOS Wallpaper Exposition v5 (roswallpexpo)

### DIFF
--- a/roswallpexpo.txt
+++ b/roswallpexpo.txt
@@ -1,10 +1,16 @@
 [Section]
 Name = ReactOS Wallpaper Exposition
-Version = 5
+Version = 6
 License = CC BY
-Description = A wallpaper set (apple, leaves, sky etc.), by fastcom.
+Description = A wallpaper collection (apple, leaves, sky etc.), by fastcom.
 Category = 16
-URLSite = https://jira.reactos.org/browse/CORE-12639
-URLDownload = https://jira.reactos.org/secure/attachment/67625/RosWallpExpo-v5.exe
-SHA1 = 2b74fb974778aa51a8695464cb695bfd0252643f
-SizeBytes = 2211512
+URLSite = https://github.com/katahiromz/RosWallpExpo
+URLDownload = https://github.com/katahiromz/RosWallpExpo/releases/download/v6/RosWallpExpo-v6.zip
+Installer = Generate
+SHA1 = 7a493c8687c462ec9eb75daacfd6ca9e1233b08e
+SizeBytes = 1699194
+
+[Generate]
+Files=RosWallpExpo-v6\*
+Dir=%SystemRoot%\Web\Wallpaper
+Lnk=!

--- a/roswallpexpo.txt
+++ b/roswallpexpo.txt
@@ -1,0 +1,10 @@
+[Section]
+Name = ReactOS Wallpaper Exposition
+Version = 1
+License = CC BY
+Description = A wallpaper set (apple, leaves, sky etc.), by fastcom.
+Category = 16
+URLSite = https://jira.reactos.org/browse/CORE-12639
+URLDownload = https://jira.reactos.org/secure/attachment/67588/ReactOSWallpaperExposition-v1.zip
+SHA1 = 3a997c41b26e90bcdc0adaf46c60c89f91ef7b5d
+SizeBytes = 999104

--- a/roswallpexpo.txt
+++ b/roswallpexpo.txt
@@ -1,10 +1,10 @@
 [Section]
 Name = ReactOS Wallpaper Exposition
-Version = 1
+Version = 5
 License = CC BY
 Description = A wallpaper set (apple, leaves, sky etc.), by fastcom.
 Category = 16
 URLSite = https://jira.reactos.org/browse/CORE-12639
-URLDownload = https://jira.reactos.org/secure/attachment/67588/ReactOSWallpaperExposition-v1.zip
-SHA1 = 3a997c41b26e90bcdc0adaf46c60c89f91ef7b5d
-SizeBytes = 999104
+URLDownload = https://jira.reactos.org/secure/attachment/67625/RosWallpExpo-v5.exe
+SHA1 = 2b74fb974778aa51a8695464cb695bfd0252643f
+SizeBytes = 2211512


### PR DESCRIPTION
Retrial of #230. This is a wallpaper set by JIRA user `fastcom`.

https://jira.reactos.org/browse/CORE-12639

![apple](https://github.com/reactos/rapps-db/assets/2107452/e5120db4-2955-47d8-ba44-d6cb80e2f127)

![leaves](https://github.com/reactos/rapps-db/assets/2107452/24e04379-3886-4258-9ac1-d442b9b763d6)

![plain](https://github.com/reactos/rapps-db/assets/2107452/0656a50a-c215-4a5b-875d-63893e320f0d)

![sky](https://github.com/reactos/rapps-db/assets/2107452/166a13a7-c2e7-4843-b8f6-da869e4b502a)

![sunset](https://github.com/reactos/rapps-db/assets/2107452/2bf13f20-58e3-45fb-b66f-9bcf77b3eace)

![VirtualBox_ReactOS_17_03_2024_13_45_26](https://github.com/reactos/rapps-db/assets/2107452/00007f99-8ba8-4e7c-989e-a78244527e55)
