### PR TITLE
[RAPPS-DB] Adding OllyDbg 1 and 2

### DIFF
--- a/ollydbg1.txt
+++ b/ollydbg1.txt
@@ -2,7 +2,7 @@
 Name=OllyDbg
 Description=32-bit assembler level analysing debugger
 Category=7
-LicenseType=2
+License=Shareware
 URLSite=http://www.ollydbg.de/
 Version=1.10
 URLDownload=http://www.ollydbg.de/odbg110.zip

--- a/ollydbg1.txt
+++ b/ollydbg1.txt
@@ -1,0 +1,15 @@
+[Section]
+Name=OllyDbg
+Description=32-bit assembler level analysing debugger
+Category=7
+LicenseType=2
+URLSite=http://www.ollydbg.de/
+Version=1.10
+URLDownload=http://www.ollydbg.de/odbg110.zip
+SHA1=8403d8049a0841887c16cf64889596ad52b84da8
+SizeBytes=1333471
+Installer=Generate
+
+[Generate]
+Files=o*|*m*.dll|*.txt
+DelFile=ollydbg.ini

--- a/ollydbg2.txt
+++ b/ollydbg2.txt
@@ -1,0 +1,15 @@
+[Section]
+Name=OllyDbg 2
+Description=OllyDbg 2 is a 32-bit assembler-level analyzing debugger with an intuitive interface.
+Category=7
+LicenseType=2
+URLSite=https://www.ollydbg.de/version2.html
+Version=2.01
+URLDownload=https://www.ollydbg.de/odbg201.zip
+SHA1=d41fe77a2801d38476f20468ab61ddce14c3abb8
+SizeBytes=6965278
+Installer=Generate
+
+[Generate]
+Files=o*.exe|*.exe|help*
+DelFile=ollydbg.ini

--- a/ollydbg2.txt
+++ b/ollydbg2.txt
@@ -2,7 +2,8 @@
 Name=OllyDbg 2
 Description=OllyDbg 2 is a 32-bit assembler-level analyzing debugger with an intuitive interface.
 Category=7
-LicenseType=2
+LicenseType=1
+License=GPLv3
 URLSite=https://www.ollydbg.de/version2.html
 Version=2.01
 URLDownload=https://www.ollydbg.de/odbg201.zip


### PR DESCRIPTION
Notes:
- The first manifests to utilize the new .zip installer feature.
- Including v1 since it is still popular in certain communities and has a big plug-in ecosystem.
- The Files wildcards are a bit strange because we don't want to install the old dbghelp and psapi dlls shipped with these programs.

![Screenshot](https://github.com/reactos/rapps-db/assets/138629473/44fba06b-6175-4bfb-8c88-bada603feb26)

