### PR TITLE
[RAPPS-DB] Add several Sysinternals tools

### DIFF
--- a/autoruns.txt
+++ b/autoruns.txt
@@ -1,0 +1,21 @@
+[Section]
+Name = Autoruns
+Description = A utility, which has the most comprehensive knowledge of auto-starting locations of any startup monitor, shows you what programs are configured to run during system bootup or login, and when you start various built-in Windows applications.
+LicenseType = 2
+Category = 12
+Publisher = Microsoft
+Version = 13.71
+URLDownload = https://web.archive.org/web/20170803195021/https://download.sysinternals.com/files/Autoruns.zip
+SHA1 = 62c0af2d62d58aa51650f1bf23d0222d43bf9bb1
+SizeBytes = 1305367
+Installer = Generate
+
+[Generate]
+Files = *s.exe|*sc.exe|*.chm
+Dir = SysInternals\AutoRuns
+DelReg = HKCU\Software\SysInternals\AutoRuns
+DelRegEmpty = HKCU\Software\SysInternals
+DelDirEmpty = .|..\.
+
+[Generate.amd64]
+Files = *s64.exe|*sc64.exe|*.chm

--- a/diskview.txt
+++ b/diskview.txt
@@ -1,0 +1,17 @@
+[Section]
+Name = DiskView
+Description = Shows you a graphical map of your disk, allowing you to determine where a file is located or, by clicking on a cluster, seeing which file occupies it.
+LicenseType = 2
+Category = 12
+Publisher = Microsoft
+Version = 2.21
+URLDownload = https://web.archive.org/web/20061123135029/http://download.sysinternals.com/Files/DiskView.zip
+SHA1 = a85a67f7884a8e71fb1ef641824fe7e748f14887
+SizeBytes = 86705
+Installer = Generate
+
+[Generate]
+Dir = SysInternals\DiskView
+DelReg = HKCU\Software\SysInternals\DiskView
+DelRegEmpty = HKCU\Software\SysInternals
+DelDirEmpty = .|..\.

--- a/filemon.txt
+++ b/filemon.txt
@@ -1,0 +1,17 @@
+[Section]
+Name = Filemon
+Description = A GUI/device driver combination that monitors and displays all file system activity on a system
+LicenseType = 2
+Category = 12
+Publisher = Microsoft
+Version = 7.3
+URLDownload = https://web.archive.org/web/20070327060603/http://www.sysinternals.com/Files/FilemonNt.zip
+SHA1 = abd212d9334b787bed9ec047d319199bb17fc977
+SizeBytes = 192932
+Installer = Generate
+
+[Generate]
+Dir = SysInternals\Filemon
+DelReg = HKCU\Software\SysInternals\Filemon
+DelRegEmpty = HKCU\Software\SysInternals
+DelDirEmpty = .|..\.

--- a/processexplorer.txt
+++ b/processexplorer.txt
@@ -1,0 +1,22 @@
+[Section]
+Name = Process Explorer
+Description = A freeware task manager and system monitor for Microsoft Windows.
+LicenseType = 2
+Category = 12
+Publisher = Microsoft
+URLSite = https://technet.microsoft.com/sysinternals/bb896653.aspx
+Version = 16.30
+URLDownload = https://web.archive.org/web/20190913041012/https://download.sysinternals.com/files/ProcessExplorer.zip
+SHA1 = 6c0237823163ba0e7b525e2f68c881d983a554af
+SizeBytes = 2004933
+Installer = Generate
+
+[Generate]
+Files = procexp.exe|*.chm
+Dir = SysInternals\Process Explorer
+DelReg = HKCU\Software\SysInternals\Process Explorer
+DelRegEmpty = HKCU\Software\SysInternals
+DelDirEmpty = .|..\.
+
+[Generate.amd64]
+Files = *64.exe|*.chm

--- a/tcpview.txt
+++ b/tcpview.txt
@@ -1,0 +1,30 @@
+[Section]
+Name = TCPView
+Description = A Windows program that will show you detailed listings of all TCP and UDP endpoints on your system, including the local and remote addresses and state of TCP connections.
+LicenseType = 2
+Category = 12
+Publisher = Microsoft
+Version = 4.17
+URLDownload = https://web.archive.org/web/20221116090816/https://download.sysinternals.com/files/TCPView.zip
+SHA1 = 94f605f83a4c08bf47d41cd74d14c2fca391cede
+SizeBytes = 2226419
+Installer = Generate
+
+[Section.x86]
+Version = 3.5
+URLDownload = https://web.archive.org/web/20210319143650/https://download.sysinternals.com/files/TCPView.zip
+SHA1 = 169cec73efc0edfcc0081f0a1ed09b70fe7a947b
+SizeBytes = 291606
+
+[Generate]
+Files = *view.exe|tcp*
+Dir = SysInternals\TCPView
+DelReg = HKCU\Software\SysInternals\TCPView
+DelRegEmpty = HKCU\Software\SysInternals
+DelDirEmpty = .|..\.
+
+[Generate.amd64]
+Files = *w64.exe|*64.exe|*.chm
+
+[Generate.arm64]
+Files = *w64a.exe|*64a.exe|*.chm

--- a/vmmap.txt
+++ b/vmmap.txt
@@ -1,0 +1,18 @@
+[Section]
+Name = VMMap
+Description = A process virtual and physical memory analysis utility.
+LicenseType = 2
+Category = 7
+Publisher = Microsoft
+Version = 3.10
+URLDownload = https://web.archive.org/web/20110726163036/http://download.sysinternals.com/files/vmmap.zip
+SHA1 = 59b65ca253c3af2dc0f010da13827efb03c7a618
+SizeBytes = 561483
+Installer = Generate
+
+[Generate]
+Files = *.exe|*.chm
+Dir = SysInternals\VMMap
+DelReg = HKCU\Software\SysInternals\VMMap
+DelRegEmpty = HKCU\Software\SysInternals
+DelDirEmpty = .|..\.

--- a/winobj.txt
+++ b/winobj.txt
@@ -1,0 +1,17 @@
+[Section]
+Name = WinObj
+Description = A must-have tool if you are a system administrator concerned about security, a developer tracking down object-related problems, or just curious about the Object Manager namespace.
+LicenseType = 2
+Category = 7
+Publisher = Microsoft
+Version = 2.22
+URLDownload = https://web.archive.org/web/20200222045401/https://download.sysinternals.com/files/WinObj.zip
+SHA1 = c5de57a34bf059aed5774bc6af4514c28dbb467d
+SizeBytes = 458395
+Installer = Generate
+
+[Generate]
+Dir = SysInternals\WinObj
+DelReg = HKCU\Software\SysInternals\WinObj
+DelRegEmpty = HKCU\Software\SysInternals
+DelDirEmpty = .|..\.

--- a/zoomit.txt
+++ b/zoomit.txt
@@ -1,0 +1,25 @@
+[Section]
+Name = ZoomIt
+Description = A screen zoom, annotation, and recording tool for technical presentations and demos.
+LicenseType = 2
+Category = 12
+Publisher = Microsoft
+URLSite = https://learn.microsoft.com/en-us/sysinternals/downloads/zoomit
+Version = 4.52
+URLDownload = https://web.archive.org/web/20210503071949/http://download.sysinternals.com/Files/ZoomIt.zip
+SHA1 = 231a7f6ee113f71f2f0e7a7cef0931c27f23501f
+SizeBytes = 939781
+Installer = Generate
+
+[Generate]
+Files = *it.exe
+Dir = SysInternals\ZoomIt
+DelReg = HKCU\Software\SysInternals\ZoomIt
+DelRegEmpty = HKCU\Software\SysInternals
+DelDirEmpty = .|..\.
+
+[Generate.amd64]
+Files = *64.exe
+
+[Generate.arm64
+Files = *64a.exe]


### PR DESCRIPTION
Adding Autoruns, DiskView, FileMon, Process Explorer, TcpView, VmMap, WinObj and ZoomIt.

Notes:
 - Some of these have 64-bit versions, I did not test if they actually work.
 - `DelDirEmpty = .|..\.` is a bit ugly but required since it was decided to use a SysInternals parent directory for these. Let me know if we should change Rapps to unconditionally delete the parent directory (if empty) instead?