### PR TITLE
[RAPPS-DB] Fix bad links of WinRAR and Audacity

### DIFF
--- a/audacity.txt
+++ b/audacity.txt
@@ -5,7 +5,7 @@ License = GPL
 Description = Free, open source, cross-platform software for recording and editing sounds.
 Category = 1
 URLSite = http://audacityteam.org/
-URLDownload = https://dreimer.eu/reactos/audacity-win-2.2.2.exe
+URLDownload = https://web.archive.org/web/20240905191907/https://www.videohelp.com/download-QLwRZLDtcw/audacity-win-2.2.2.exe
 SHA1 = 39d00d43e72a7944f433d3f61855a487b5797328
 SizeBytes = 20248056
 

--- a/winrar.txt
+++ b/winrar.txt
@@ -5,12 +5,12 @@ License = EULA
 Description = WinRAR is a popular archive manager to compress or decompress files, it has its own format for compression without much loss (.rar).
 Category = 12
 URLSite = https://www.winrar.es/
-URLDownload = https://d.winrar.es/d/37z1698371810/RFzd3_5bGHP3zappyENuyQ/winrar-x32-624.exe
+URLDownload = https://www.rarlab.com/rar/winrar-x32-624.exe
 SHA1 = 25026a74b8349ffff4246791be60c37ec02ef631
 SizeBytes = 3317040
 
 [Section.amd64]
-URLDownload = https://d.winrar.es/d/101z1698782528/sEM6qGk6vq0hkzBNNL4Mxw/winrar-x64-624.exe
+URLDownload = https://www.rarlab.com/rar/winrar-x64-624.exe
 SHA1 = aa5e8d9fd7d613a163acebcccefdfd33bb18c8cd
 SizeBytes = 3589048
 


### PR DESCRIPTION
I will replace the links available under rapps-db because the old repositories that where now are not available. 

Audacity have the bad thing that they host the executable in a site that have a single tocken/link for each download try, so... It's a bit tricky to find it in a decent place and not to fight with enormous links.

And WinRAR, it has now a link that is not the most official one, because it's the Spanish official one, that must be corrected. Not sure how long this link will be available since this is licensed - non open software.