### PR TITLE
[RAPPS-DB] Fix Folder2Iso x86 download

### DIFF
--- a/Folder2Iso.txt
+++ b/Folder2Iso.txt
@@ -5,11 +5,10 @@ License = EULA
 Description = Folder2Iso is a portable Windows and Linux application that creates an ISO from any folder.
 Category = 12
 URLSite = https://www.trustfm.net/software/utilities/Folder2Iso.php
-URLDownload = https://ia802807.us.archive.org/27/items/folder2iso_202001/Folder2Iso.zip
-SHA1 = 07c1641ada57f31964eb4327d5753ab310fc5975
-SizeBytes = 2736100
+URLDownload = https://web.archive.org/web/2024im_/https://drive.usercontent.google.com/download?id=0B7nKMWPhyfl-UlYyV1NzclVET00&confirm=t&_/Folder2Iso31.exe
+SHA1 = 93662ee7417ad23e3a4e5cb3bd3091f805dcb075
+SizeBytes = 2749292
 Icon = folder2iso.ico
-Installer = Generate
 
 [Section.amd64]
 URLDownload = https://ia802807.us.archive.org/27/items/folder2iso_202001/Folder2Iso.zip


### PR DESCRIPTION
The previous download incorrectly pointed to a AMD64 release. This new ugly link is from the official website.