### PR TITLE
[RAPPS-DB] Convert more zip packages to zip installers

### DIFF
--- a/ccleste.txt
+++ b/ccleste.txt
@@ -7,6 +7,11 @@ URLSite = https://github.com/lemon32767/ccleste
 URLDownload = https://github.com/lemon32767/ccleste/releases/download/v1.4.0/ccleste-win.zip
 SHA1 = 25daffeeb4445de62e6fc162ade04f65c16dd70c
 SizeBytes = 2972378
+Installer = Generate
+
+[Generate]
+Files = ccleste.exe|*
+DelFile = ccleste-input-cfg.txt
 
 [Section.041f]
 Description = 3DS ve PC için Celeste Classic C kaynak portu.

--- a/cstalin.txt
+++ b/cstalin.txt
@@ -8,6 +8,11 @@ URLSite = http://commanderstalin.sourceforge.net/
 URLDownload = http://download.sourceforge.net/project/commanderstalin/commander%20stalin%20version%203/version3/cstalin-0.9.5-win.zip
 SHA1 = 736b89d96c025bdf0b17116b4b8f26424e219669
 SizeBytes = 273683958
+Installer = Generate
+
+[Generate]
+Files = cstalin-0.9.5-win\c*.exe|cstalin-0.9.5-win\*
+DelDirEmpty = boswars\save|boswars
 
 [Section.0a]
 Description = Un juego de estrategia en tiempo real con tintes soviéticos.

--- a/desmume.txt
+++ b/desmume.txt
@@ -8,6 +8,10 @@ URLSite = https://desmume.org
 URLDownload = https://download.sourceforge.net/project/desmume/desmume/0.9.11/desmume-0.9.11-win32.zip
 SHA1 = 3040b9c5457f623c33b98cbeb7f35343aaf6748e
 SizeBytes = 1194684
+Installer = Generate
+
+[Generate]
+DelFile = desmume.ini
 
 [Section.amd64]
 URLDownload = https://download.sourceforge.net/project/desmume/desmume/0.9.11/desmume-0.9.11-win64.zip

--- a/fall.txt
+++ b/fall.txt
@@ -8,6 +8,10 @@ URLSite = http://insomnia.sourceforge.net/fall/fall.html
 URLDownload = http://download.sourceforge.net/project/insomnia/fall/stable/Fall-win32.zip
 SHA1 = b8364dd7a015c1b9d5dbb2e8ac3cad34f803f0cb
 SizeBytes = 379782
+Installer = Generate
+
+[Generate]
+Files = Fall-win32\*.exe|Fall-win32\*
 
 [Section.0a]
 Description = Los pingüinos están cayendo desde un iceberg y tienes que introducirlo en la barca.

--- a/fbide.txt
+++ b/fbide.txt
@@ -9,6 +9,10 @@ URLDownload = https://altushost-swe.dl.sourceforge.net/project/fbide/fbide%200.4
 SHA1 = 326327c7082adae0af1df0281cde4af990b1e273
 SizeBytes = 3132022
 Icon = fbide.ico
+Installer = Generate
+
+[Generate]
+Files = FBIde0.4.6r4\*.exe|FBIde0.4.6r4\*
 
 [Section.041f]
 License = GPL sürüm 3

--- a/flashplayer32.txt
+++ b/flashplayer32.txt
@@ -2,7 +2,7 @@
 Name = Adobe Flash Player 32
 Version = 32.0.0.101
 License = Freeware
-Description = A 32 bits Flash player that can run SWF files.
+Description = A 32-bit Flash player that can run SWF files.
 Category = 12
 URLSite = https://www.adobe.com/
 URLDownload = https://fpdownload.macromedia.com/pub/flashplayer/updaters/32/flashplayer_32_sa.exe

--- a/hiawatha.txt
+++ b/hiawatha.txt
@@ -8,6 +8,14 @@ URLSite = https://www.hiawatha-webserver.org/
 URLDownload = https://web.archive.org/web/2024if_/https://www.hiawatha-webserver.org/files/hiawatha-9/hiawatha-9.15.zip
 SHA1 = 6ada69afdeb3f75ceda0c19c67d562a5052a9949
 SizeBytes = 3560500
+Installer = Generate
+
+[Generate]
+Files = Hiawatha\Hiawatha.bat|*.txt|Hiawatha\*
+DelFile = work\hiawatha.pid
+DelDir = logfiles
+DelDirEmpty = work\upload|work
+DelRegEmpty = HKCU\Software\Cygwin\Program Options|HKCU\Software\Cygwin
 
 [Section.0a]
 Description = Un webserver de licencia abierta centrado en la seguridad.

--- a/kompozer.txt
+++ b/kompozer.txt
@@ -8,6 +8,12 @@ URLSite = http://www.kompozer.net/
 URLDownload = http://download.sourceforge.net/project/kompozer/current/0.7.10/kompozer-0.7.10-win32.zip
 SHA1 = cb0fbb2f9d4a547131176158e9e7185ee525a8a3
 SizeBytes = 7949158
+Installer = Generate
+
+[Generate]
+Files = KompoZer 0.7.10\k*.exe|KompoZer 0.7.10\*
+DelFile = components.ini|defaults.ini
+DelDir = chrome|components|extensions
 
 [Section.0a]
 Description = Un completo sistema de autoría web que combina la gestión de archivos web y una interfaz WYSIWYG fácil de usar en la edición web.

--- a/lgeneral.txt
+++ b/lgeneral.txt
@@ -8,6 +8,11 @@ URLSite = http://lgames.sourceforge.net/index.php?project=LGeneral
 URLDownload = https://sourceforge.net/projects/lgeneral/files/lgeneral/lgeneral-1.4.4-win32.zip
 SHA1 = 85925fbee97d0fbd3af7ee09639e68c7d7667dde
 SizeBytes = 6161244
+Installer = Generate
+
+[Generate]
+Files = lgeneral-1.4.4-win32\lgen*.exe|lgeneral-1.4.4-win32\*
+DelFile = lgeneral.conf|stderr.txt|stdout.txt
 
 [Section.0a]
 Description = Clon de Panzer General usando las librerias SDL.

--- a/maelstorm.txt
+++ b/maelstorm.txt
@@ -9,6 +9,11 @@ URLDownload = http://slouken.libsdl.org/projects/Maelstrom/bin/Maelstrom-3.0.6-W
 SHA1 = b47b44f1767bf7ed375ad60cb6376d3178f1824d
 SizeBytes = 906220
 Icon = maelstorm.ico
+Installer = Generate
+
+[Generate]
+Files = Maelstrom-3.0.6\*.exe|Maelstrom-3.0.6\*
+DelFile = .Maelstrom-data
 
 [Section.041f]
 Description = Maelstrom, Macintosh için orijinal shareware oyunun GPL'leştirilmiş bir uyarlamasıdır. Ayrıntılı grafikleri ve özgün sesleriyle hızlı eylemli ve yüksek çözünürlüklü (640x480) Astreoids benzeri bir oyundur.

--- a/rainmeter.txt
+++ b/rainmeter.txt
@@ -7,7 +7,7 @@ Category = 12
 URLSite = https://www.rainmeter.net/
 URLDownload = https://github.com/rainmeter/rainmeter/releases/download/v3.3.3.2744/Rainmeter-3.3.3.exe
 Icon=rainmeter.ico
-Screenshot1 = https://i.imgur.com/oj6yqE2.png
+Screenshot1 = https://web.archive.org/web/2023im_/https://i.imgur.com/oj6yqE2.png
 SHA1 = eac2d350cac138c9ece86fe9ccd823e380601b1c
 SizeBytes = 2404088
 

--- a/xrick.txt
+++ b/xrick.txt
@@ -9,6 +9,10 @@ URLDownload = http://www.bigorno.net/xrick/xrick-021212-win32.zip
 SHA1 = 0fdd9641003c8181670abd4edc7345c685dfbabd
 SizeBytes = 1645879
 Icon = xrick.ico
+Installer = Generate
+
+[Generate]
+Files = xrick-021212-win32\*.exe|xrick-021212-win32\*
 
 [Section.041f]
 Description = xrick, bir Rick Dangerous klonudur.


### PR DESCRIPTION
Notes:
- ccleste, cstalin, fall, maelstorm and xrick rely on the recently added Rapps shortcut working directory enhancement to run correctly.
- CStalin defaults to Spanish but that is a flaw in their .zip distribution and not something this PR can fix.
- Neverball should probably be converted at some point but I could not get it to run in my VM.
- Openarena should probably be converted at some point but it's so large, I did not test it.