### PR TITLE
[RAPPS-DB] Update RosBE, WinSpy and minor fixes

### DIFF
--- a/deathrally.txt
+++ b/deathrally.txt
@@ -11,4 +11,4 @@ URLDownload = https://web.archive.org/web/201502im_/http://gamedaily.newaol.com/
 SHA1 = bda2a2230c01580ac779f3cf0f5954d234c8c78e
 SizeBytes = 43574432
 SaveAs = DeathRallyWin_10.exe
-Screenshot1 = http://upload.wikimedia.org/wikipedia/en/5/5b/Death_Rally_cover.jpg
+Screenshot1 = https://web.archive.org/web/2024im_/https://upload.wikimedia.org/wikipedia/en/5/5b/Death_Rally_cover.jpg

--- a/iqpuzzle.txt
+++ b/iqpuzzle.txt
@@ -11,7 +11,7 @@ SHA1 = 8ebff94a5cd0f6747d2160807bdb98376bf3f471
 SizeBytes = 7718068
 Icon = iqpuzzle.ico
 Screenshot1 = https://user-images.githubusercontent.com/26674558/166152612-90f722f6-e937-4b11-8c4c-160c3568e267.png
-Languages = 0407|0809|040C|0410|0413|0412|0414|0402|0804|0408|0404|0016|0416|0019
+Languages = 0407|0809|040C|0409|0410|0413|0412|0414|0402|0804|0408|0404|0016|0416|0019
 
 [Section.0404]
 Description = 一款有趣且具有挑戰性的的五格骨牌。

--- a/rosbe.txt
+++ b/rosbe.txt
@@ -1,13 +1,14 @@
 [Section]
 Name = ReactOS Build Environment
-Version = 2.1.6
+Version = 2.2.1
 License = GPL
+LicenseType = 1
 Description = Allows you to build the ReactOS source. For more instructions see ReactOS wiki.
 Category = 7
 URLSite = http://reactos.org/wiki/Build_Environment
-URLDownload = https://download.sourceforge.net/reactos/RosBE-2.1.6.exe
-SHA1 = 01b195f442cea01bcf21536f1c2e5d898ba9fe0c
-SizeBytes = 37300572
+URLDownload = https://download.sourceforge.net/reactos/RosBE-2.2.1.exe
+SHA1 = cf63683aa76b9e3d00bae71310ed5875f4c29fb2
+SizeBytes = 77584546
 
 [Section.0a]
 Description = Te permite compilar el código de ReactOS. Para más información consulta la Wiki de ReactOS.

--- a/stackandconquer.txt
+++ b/stackandconquer.txt
@@ -11,7 +11,7 @@ SHA1 = d78c532297648fc4c9aeca77865d1970c5d7b054
 SizeBytes = 8723175
 Icon = stackandconquer.ico
 Screenshot1 = https://user-images.githubusercontent.com/26674558/166152607-0998f184-c0c6-48ef-baea-73e89f9c9fdd.png
-Languages = 0407|0809|0410|0413
+Languages = 0407|0809|0409|0410|0413
 
 [Section.0407]
 Description = Ein anspruchsvolles Tower Conquest Brettspiel

--- a/superfinder.txt
+++ b/superfinder.txt
@@ -1,10 +1,11 @@
 [Section]
 Name = Super Finder XT
 Version = 1.6.3.2
+RegName = Super Finder XT_is1
 License = Freeware
 Description = A fast and feature rich search application.
 Category = 12
-URLSite = http://fsl.sytes.net/ssearchxt.html
+URLSite = http://freesoftland.net/ssearchxt.html
 URLDownload = https://web.archive.org/web/20110401000000/http://www.webalice.it/guido.vinaio/releases/setup_SuperFinderXT.exe
 SHA1 = 11dc368582e7055cbc19d9b1a8a30b2f6e2e3601
 SizeBytes = 5184839

--- a/winspypp.txt
+++ b/winspypp.txt
@@ -1,7 +1,8 @@
 [Section]
 Name = Winspy++
 Version = 1.7
-License = Freeware
+License = MIT
+LicenseType = 1
 Description = A handy programmer's utility which can be used to select and view the properties of any window in the system.
 Category = 7
 URLSite = http://www.catch22.net/software/winspy
@@ -13,6 +14,12 @@ Installer = Generate
 [Generate]
 DelReg = HKCU\Software\Catch22\WinSpy++ 1.5
 DelRegEmpty = HKCU\Software\Catch22
+
+[Section.amd64]
+Version = 1.8.4
+URLDownload = https://github.com/strobejb/winspy/releases/download/v1.8.4/WinSpy_Release_x64.zip
+SHA1 = 8A1D6AA8F231FD73B284B3776F8036BFA6373F7E
+SizeBytes = 106821
 
 [Section.0a]
 Description = Una herramienta práctica para programadores que puede ser usada para seleccionar y ver las propiedades de cualquier ventana del sistema.
@@ -41,4 +48,3 @@ Description = Sistemdeki bir pencerenin özelliklerini görüntülemek ve seçme
 [Section.0804]
 License = 免费软件
 Description = 一款能够用来选择和查看系统中任意窗口属性的面向高级程序员的实用工具。
-

--- a/zoomit.txt
+++ b/zoomit.txt
@@ -1,7 +1,8 @@
 [Section]
 Name = ZoomIt
 Description = A screen zoom, annotation, and recording tool for technical presentations and demos.
-LicenseType = 2
+License = MIT
+LicenseType = 1
 Category = 12
 Publisher = Microsoft
 URLSite = https://learn.microsoft.com/en-us/sysinternals/downloads/zoomit


### PR DESCRIPTION
RosBE has to be updated because the old version does not work on current master "(CMake Error at CMakeLists.txt:2 (cmake_minimum_required): CMake 3.17.0 or higher is required.)".

I have verified that the new version successfully installs on 0.4.14, can `configure.cmd&cd output-MinGW-i386&ninja winver` successfully on current master in 0.4.14 (and in 0.4.16 of course) and can `configure.cmd&cd output-MinGW-i386&ninja winver` successfully on reactos-0.4.14-release.zip.

----

I'm adding a newer WinSpy++ version for x64 but keeping the old one for x86 because the new version uses layered windows and ROS does not fully support those. There is no older x64 version we can use.

