### PR TITLE
[RAPPS-DB] Add TweakUI and extra MS visual styles

### DIFF
--- a/royalenoirtheme.txt
+++ b/royalenoirtheme.txt
@@ -1,0 +1,16 @@
+[Section]
+Name = Royale Noir
+License = Freeware
+LicenseType = 2
+Description = Royale Noir is an almost exact copy of Royale except with a dark purplish tint.
+Category = 15
+URLSite = https://istartedsomething.com/20061029/royale-noir/
+URLDownload = https://web.archive.org/web/20250404212305im_/https://fs12n3.sendspace.com/dl/ad1b2bb86900f5dea662d4064bd6c56d/67f04d93416101f6/ouby5o/royale_noir.zip
+SHA1 = b3b97d7a145808dc17b4699ca9a6f96ca9d2beca
+SizeBytes = 385099
+Installer = Generate
+
+[Generate]
+Dir = %systemroot%\Resources\Themes\RoyaleNoir
+Lnk = !
+Icon = ..\..\..\system32\desk.cpl

--- a/royaletheme.txt
+++ b/royaletheme.txt
@@ -1,0 +1,11 @@
+[Section]
+Name = Royale
+Publisher = Microsoft
+License = Freeware
+LicenseType = 2
+Description = Royale (also known as Energy Blue and Media Center style) is a visual style designed for Windows XP Media Center Edition 2005. Also includes the New Bliss wallpaper.
+Category = 15
+URLSite = https://web.archive.org/web/20051028063258if_/http://www.microsoft.com/nz/windowsxp/downloads/nzbliss.aspx
+URLDownload = https://web.archive.org/web/20051128025233im_/http://download.microsoft.com/download/a/c/4/ac407ba2-30d2-447b-8c93-83967a92dd9f/royale.zip
+SHA1 = 08d5face1bbe9cde6944b8b5ae453fe2a117faec
+SizeBytes = 688390

--- a/tweakui.txt
+++ b/tweakui.txt
@@ -1,0 +1,17 @@
+[Section]
+Name = TweakUI 2
+Version = 2.10
+Publisher = Microsoft
+License = Freeware
+LicenseType = 2
+Description = This PowerToy gives you access to system settings that are not exposed in the default user interface, including mouse settings, Explorer settings, taskbar settings, and more.
+Category = 12
+URLSite = https://web.archive.org/web/200602if_/http://www.microsoft.com/windowsxp/downloads/powertoys/xppowertoys.mspx
+URLDownload = https://web.archive.org/web/20060317201822im_/http://download.microsoft.com/download/f/c/a/fca6767b-9ed9-45a6-b352-839afb2a2679/TweakUiPowertoySetup.exe
+SHA1 = d8b623f6ebfea42b3286e4c0c3ba637ffabcb704
+SizeBytes = 150192
+
+[Section.amd64]
+URLDownload = https://web.archive.org/web/20240511215442im_/https://cfcdn.neosmart.net/software/TweakUI/TweakUI_64Bit.msi?response-content-disposition=attachment%3B%20filename%3D%22TweakUI_64Bit.msi%22&response-cache-control=max-age%3D1209600&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9jZmNkbi5uZW9zbWFydC5uZXQvc29mdHdhcmUvVHdlYWtVSS9Ud2Vha1VJXzY0Qml0Lm1zaT9yZXNwb25zZS1jb250ZW50LWRpc3Bvc2l0aW9uPWF0dGFjaG1lbnQlM0IlMjBmaWxlbmFtZSUzRCUyMlR3ZWFrVUlfNjRCaXQubXNpJTIyXHUwMDI2cmVzcG9uc2UtY2FjaGUtY29udHJvbD1tYXgtYWdlJTNEMTIwOTYwMCIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTcxNTQ2ODA1NX19fV19&Signature=jB8YXnD2agGZvRCUczb9lvriVi3YFtGNJYzODOt8ymiNH4Rt8hTaEPb4VSu90gWIg8Pg9SxofOWdJA287P5G0O4raiDmm2nED29QY1OcABJZO4raPdE-U6XbprjtaC5T9wJ-91diEojULxOOimOBiZObpcMwgtOukJ043e-M-3r8qTGUk~YWyYS5qOiddiaFjipZRvzP2pYx05KcUjargCgc6~ut9oo7oTdRek0XPXlgkJBVcq4-toljJ05zFkqAFUL3q6BsBLmFtO1MlOM6XBN4U7klHst9nWKxEV~fyLc6uakwPbcIQsurC-VdALOeg1arjZ3PFN0fxtO9TX707g__&Key-Pair-Id=APKAIPY5GEV5EHVOFFNQ
+SHA1 = 13b7c11b98c7e4ab74fd157446fc002b6b7112ad
+SizeBytes = 689664

--- a/tweakui1.txt
+++ b/tweakui1.txt
@@ -1,0 +1,18 @@
+[Section]
+Name = TweakUI
+Version = 1.33
+Publisher = Microsoft
+License = Freeware
+LicenseType = 2
+Description = Adjust your Windows User Interface, including menu speed, window animation, and Microsoft Internet Explorer.
+Category = 12
+URLSite = https://web.archive.org/web/20040405071854if_/http://www.microsoft.com/ntworkstation/downloads/powertoys/networking/NTTweakUI.asp
+URLDownload = https://archive.org/download/ms_tweakui/TweakUI.zip
+SHA1 = aa0b0c24c3ebd486bfc5d2751815c6fc01b35ea2
+SizeBytes = 83283
+Installer = Generate
+
+[Generate]
+Files = TweakUI\t*.cpl|TweakUI\t*
+Dir = %SystemRoot%\system32
+Lnk = !

--- a/zunetheme.txt
+++ b/zunetheme.txt
@@ -1,0 +1,11 @@
+[Section]
+Name = Zune
+Publisher = Microsoft
+License = Freeware
+LicenseType = 2
+Description = The official Zune desktop theme. Note: You must set the compatibility on the .msi to Windows XP SP3 before installing.
+Category = 15
+URLSite = https://web.archive.org/web/20061128062226if_/http://www.zune.net:80/en-us/meetzune/device.htm
+URLDownload = https://web.archive.org/web/20130224083838im_/http://download.microsoft.com/download/e/a/9/ea9af5ae-b48e-473e-85fe-dcde7472e644/ZuneDesktopTheme.msi
+SHA1 = 67fa6461855488ab4fd3907d91b229e5124d0843
+SizeBytes = 1722880


### PR DESCRIPTION
Notes:
- Royale/Energy Blue is the one released by Microsoft New Zealand that includes the new bliss wallpaper (New Bliss.jpg). The other version _("Microsoft Windows XP Tablet PC Edition 2005 Energy Blue Theme Pack")_ (with EnergyBliss.jpg) is available [here](https://web.archive.org/web/20051124174056/http://download.microsoft.com/download/5/2/9/5295fa0c-575a-4ee6-b186-0a8cf7ddfde6/WindowsXP-TabletPC-EnergyBlueTheme-x86-ENU.exe) but will only install on XP Tablet PC edition.
- [Royale Noir](https://www.betaarchive.com/wiki/index.php/Windows/Visual_Styles/Royale_Noir) is signed by Microsoft and works on stock Windows XP but I'm not sure where it was initially released, probably somewhere on Channel 9. The download points to a .zip with the name fixed from Luna to Royale Noir so it does not conflict with the real Luna.
- The Zune theme installer requires the user to set compatibility settings on the .msi. Perhaps Rapps could gain the ability to do this automatically in the future?
- Neither version of TweakUI works perfectly so I included both.
- TweakUI v2 will not uninstall because it uses a custom MSHTA uninstaller that needs Trident+WScript.