### PR TITLE
[RAPPS-DB] Update SuperTuxKart and Vim version

### DIFF
--- a/supertuxkart.txt
+++ b/supertuxkart.txt
@@ -1,18 +1,18 @@
 [Section]
 Name = SuperTuxKart
-Version = 1.3
+Version = 1.5
 License = GPLv3
 Description = A 3D racing game featuring many mascots of open source projects.
 Category = 4
 URLSite = https://supertuxkart.net/Main_Page
-URLDownload = https://master.dl.sourceforge.net/project/supertuxkart/SuperTuxKart/1.3/SuperTuxKart-1.3-installer-i686.exe
-SHA1 = b7ac890fcec9e51e9f2f55298354cc19d598a772
-SizeBytes = 638616712
+URLDownload = https://master.dl.sourceforge.net/project/supertuxkart/SuperTuxKart/1.5/SuperTuxKart-1.5-installer-i686.exe
+SHA1 = 61731016afaa2fc8d8d185aac83c9dfb6fdb6027
+SizeBytes = 723623185
 
 [Section.amd64]
-URLDownload = https://master.dl.sourceforge.net/project/supertuxkart/SuperTuxKart/1.3/SuperTuxKart-1.3-installer-i686.exe
-SHA1 = b7ac890fcec9e51e9f2f55298354cc19d598a772
-SizeBytes = 638616712
+URLDownload = https://master.dl.sourceforge.net/project/supertuxkart/SuperTuxKart/1.5/SuperTuxKart-1.5-installer-x86_64.exe
+SHA1 = 75fa5a2ca7734c17c104ce40bc052b8704322a69
+SizeBytes = 723247478
 
 [Section.arm]
 Version = 1.3

--- a/vim.txt
+++ b/vim.txt
@@ -1,18 +1,18 @@
 [Section]
 Name = VIM - Vi IMproved
-Version = 8.2.5171
+Version = 9.0.0494
 License = GPL-compatible charityware
 LicenseType = 1
 Description = Vim is a highly configurable text editor built to enable efficient text editing. It is an improved version of the vi editor distributed with most UNIX systems.
 Category = 7
 URLSite = https://www.vim.org/
-URLDownload = https://github.com/vim/vim-win32-installer/releases/download/v8.2.5171/gvim_8.2.5171_x86_signed.exe
+URLDownload = https://github.com/vim/vim-win32-installer/releases/download/v9.0.0494/gvim_9.0.0494_x86.exe
 Screenshot1 = https://i.imgur.com/PzitUVC.png
-SHA1 = 40b579d4ea767a533524256a289e4e14eb8a4c81
-SizeBytes = 9841432
+SHA1 = ab1eaff0d71708794c417c7c7cdf0d4fa2322d4d
+SizeBytes = 9917204
 
 [Section.amd64]
-URLDownload = https://github.com/vim/vim-win32-installer/releases/download/v8.2.5171/gvim_8.2.5171_x64_signed.zip
+URLDownload = https://github.com/vim/vim-win32-installer/releases/download/v9.0.0494/gvim_9.0.0494_x64.exe
 Screenshot1 = https://i.imgur.com/IWTOJH1.png
-SHA1 = e74858e328ee1d1d05c9dd66dfb366b89ada89e1
-SizeBytes = 20577877
+SHA1 = a8ef6f5a756d65557853cadd543315b37be31260
+SizeBytes = 10498098


### PR DESCRIPTION
Not sure if it's okay to update 2 apps in 1 PR, let me know if I need to split it into two PRs.

1. SuperTuxKart
   Updated to v1.5. Works as well (or bad) as v1.3 on my Virtual Box VM. I didn't see much performance difference.
   For example, both complains about old driver and recommend OpenGL v3.3 and above. Both are around 10~15fps at lowest settings, so I would't complain more to update it :(
<img width="3556" height="2196" alt="Screenshot From 2026-07-16 12-12-36" src="https://github.com/user-attachments/assets/e1953ae2-f319-4963-8dd6-09ebc53de1f6" />


2. Vim
   I found the latest version for Windows XP is [v9.0.0494](https://github.com/vim/vim-win32-installer/releases/tag/v9.0.0494), before they [dropped support in 9.0.0496](https://github.com/vim/vim/commit/27b53be3a6a340f1858bcd31233fe2efc86f8e15). This version works well as I tested.
<img width="3556" height="2196" alt="Screenshot From 2026-07-16 12-13-21" src="https://github.com/user-attachments/assets/082735e9-a4c7-462b-a1b1-8430bc81ceae" />
