### PR TITLE
[RAPPS-DB] Use `SaveAs` to avoid VC and .NET installer name collisions

### DIFF
--- a/net11.txt
+++ b/net11.txt
@@ -8,6 +8,7 @@ URLSite = https://www.microsoft.com/en-US/download/details.aspx?id=26
 URLDownload = https://web.archive.org/web/20210505032023if_/http://download.microsoft.com/download/a/a/c/aac39226-8825-44ce-90e3-bf8203e74006/dotnetfx.exe
 SHA1 = 16a354a2207c4c8846b617cbc78f7b7c1856340e
 SizeBytes = 24265736
+SaveAs = dotnetfx11.exe
 Icon = oldwinsetup.ico
 
 [Section.0a]

--- a/net20.txt
+++ b/net20.txt
@@ -8,6 +8,7 @@ URLSite = https://www.microsoft.com/downloads/details.aspx?FamilyID=0856eacb-436
 URLDownload = https://web.archive.org/web/20210505034809if_/http://download.microsoft.com/download/5/6/7/567758a3-759e-473e-bf8f-52154438565a/dotnetfx.exe
 SHA1 = a3625c59d7a2995fb60877b5f5324892a1693b2a
 SizeBytes = 23510720
+SaveAs = dotnetfx20.exe
 Icon = oldwinsetup.ico
 
 [Section.0a]

--- a/vc2005sp1run.txt
+++ b/vc2005sp1run.txt
@@ -8,6 +8,7 @@ URLSite = https://www.microsoft.com/en-us/download/details.aspx?id=26347
 URLDownload = https://web.archive.org/web/20201112025512/http://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x86.EXE
 SHA1 = b8fab0bb7f62a24ddfe77b19cd9a1451abd7b847
 SizeBytes = 2707352
+SaveAs = vcredist_x86_vs2005.EXE
 Icon = oldwinsetup.ico
 SilentParameters = /Q
 
@@ -18,6 +19,7 @@ RegName = {710f4c1c-cc18-4c49-8cbf-51240c89a1a2}
 URLDownload = https://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x64.EXE
 SHA1 = f4d74643a0e117ea80b2c7ebcd908a6dd26aa9ea
 SizeBytes = 3179000
+SaveAs = vcredist_x64_vs2005.EXE
 RegName = {ad8a2fa1-06e7-4b0d-927d-6e54b3d31028}
 
 [Section.0a]

--- a/vc2008sp1run.txt
+++ b/vc2008sp1run.txt
@@ -8,6 +8,7 @@ URLSite = https://www.microsoft.com/en-us/download/details.aspx?id=26368
 URLDownload = https://web.archive.org/web/20200819111521/http://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe
 SHA1 = 470640aa4bb7db8e69196b5edb0010933569e98d
 SizeBytes = 4479832
+SaveAs = vcredist_x86_vs2008.exe
 Icon = oldwinsetup.ico
 SilentParameters = /q /norestart
 
@@ -18,6 +19,7 @@ RegName = {9BE518E6-ECC6-35A9-88E4-87755C07200F}
 URLDownload = https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe
 SHA1 = ce8ff6572e86b0bba39d88fa3a6d56b59100613d
 SizeBytes = 5211080
+SaveAs = vcredist_x64_vs2008.exe
 RegName = {5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}
 
 [Section.0a]

--- a/vc2010sp1run.txt
+++ b/vc2010sp1run.txt
@@ -8,6 +8,7 @@ URLSite = https://www.microsoft.com/en-us/download/details.aspx?id=26999
 URLDownload = https://web.archive.org/web/20200810231845/http://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe
 SHA1 = 28c54491be70c38c97849c3d8cfbfdd0d3c515cb
 SizeBytes = 8990552
+SaveAs = vcredist_x86_vs2010.exe
 Icon = newwinsetup.ico
 SilentParameters = /quiet /norestart
 
@@ -18,6 +19,7 @@ RegName = {F0C3E5D1-1ADE-321E-8167-68EF0DE699A5}
 URLDownload = https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe
 SHA1 = 8691972f0a5bf919701ac3b80fb693fc715420c2
 SizeBytes = 10277328
+SaveAs = vcredist_x64_vs2010.exe
 RegName = {1D8E6291-B0D5-35EC-8441-6616F567A0F7}
 
 [Section.0a]

--- a/vc2012run.txt
+++ b/vc2012run.txt
@@ -8,17 +8,20 @@ URLSite = https://www.microsoft.com/en-us/download/details.aspx?id=30679
 URLDownload = https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe
 SHA1 = 96b377a27ac5445328cbaae210fc4f0aaa750d3f
 SizeBytes = 6554576
+SaveAs = vcredist_x86_vs2012.exe
 Icon = newwinsetup.ico
 
 [Section.amd64]
 URLDownload = https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe
 SHA1 = 1a5d93dddbc431ab27b1da711cd3370891542797
 SizeBytes = 7186992
+SaveAs = vcredist_x64_vs2012.exe
 
 [Section.arm]
 URLDownload = https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU4/vcredist_arm.exe
 SHA1 = dc9850bb24ca10160e33fc37590a2dc689827acf
 SizeBytes = 1453976
+SaveAs = vcredist_arm_vs2012.exe
 
 [Section.0a]
 Description = Necesario para aplicaciones compiladas con Visual Studio 2012. Incluye: atl110.dll, mfc110.dll, mfc110u.dll, mfcm110.dll, mfcm110u.dll, msdia110.dll, msvcm110.dll, msvcp110.dll, msvcr110.dll, vcomp110.dll.

--- a/vc2013run.txt
+++ b/vc2013run.txt
@@ -8,6 +8,7 @@ URLSite = https://www.microsoft.com/en-us/download/details.aspx?id=40784
 URLDownload = https://download.visualstudio.microsoft.com/download/pr/10912113/5da66ddebb0ad32ebd4b922fd82e8e25/vcredist_x86.exe
 SHA1 = 0f5d66bcaf120f2d3f340e448a268fe4bbf7709d
 SizeBytes = 6510136
+SaveAs = vcredist_x86_vs2013.exe
 Icon = newwinsetup.ico
 SilentParameters = /install /quiet /norestart
 
@@ -19,6 +20,7 @@ Version = 12.0.30501.0
 URLDownload = https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe
 SHA1 = 8bf41ba9eef02d30635a10433817dbb6886da5a2
 SizeBytes = 7194312
+SaveAs = vcredist_x64_vs2013.exe
 RegName = {050d4fc8-5d48-4b8f-8972-47c82c46020f}
 
 [Section.arm]
@@ -26,6 +28,7 @@ Version = 12.0.30501.0
 URLDownload = https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_arm.exe
 SHA1 = 25786706a58490884623842b0bbc886ac86e2cad
 SizeBytes = 1420840
+SaveAs = vcredist_arm_vs2013.exe
 
 [Section.0a]
 Description = Necesario para aplicaciones compiladas con Visual Studio 2013. Incluye: atl120.dll, mfc120.dll, mfc120u.dll, mfcm120.dll, mfcm120u.dll, msdia120.dll, msvcm120.dll, msvcp120.dll, msvcr120.dll, vcomp120.dll.

--- a/vc2015run.txt
+++ b/vc2015run.txt
@@ -8,6 +8,7 @@ URLSite = https://www.microsoft.com/en-us/download/details.aspx?id=53587
 URLDownload = https://download.microsoft.com/download/6/D/F/6DF3FF94-F7F9-4F0B-838C-A328D1A7D0EE/vc_redist.x86.exe
 SHA1 = 89f20df555625e1796a60bba0fbd2f6bbc627370
 SizeBytes = 14458272
+SaveAs = vc_redist.x86_vs2015.exe
 SilentParameters = /install /quiet /norestart
 Icon = newwinsetup.ico
 
@@ -18,6 +19,7 @@ RegName = {462f63a8-6347-4894-a1b3-dbfe3a4c981d}
 URLDownload = https://download.microsoft.com/download/6/D/F/6DF3FF94-F7F9-4F0B-838C-A328D1A7D0EE/vc_redist.x64.exe
 SHA1 = cd2fce1bf61637b2536b66ee52a9662473bbdc82
 SizeBytes = 15302984
+SaveAs = vc_redist.x64_vs2015.exe
 
 [Section.arm]
 Version = 14.0.24245.0

--- a/vc2015to2019run.txt
+++ b/vc2015to2019run.txt
@@ -7,4 +7,5 @@ Category = 14
 URLDownload = https://aka.ms/vs/16/release/14.29.30133/VC_Redist.x86.exe
 SHA1 = 2c1ae47103e7f8d6072df4a8d9ceb382724ac59b
 SizeBytes = 13782872
+SaveAs = VC_Redist.x86_vs2019.exe
 Icon = newwinsetup.ico

--- a/vc2017run.txt
+++ b/vc2017run.txt
@@ -7,6 +7,7 @@ Category = 14
 URLDownload = https://aka.ms/vs/15/release/vc_redist.x86.exe
 SHA1 = d6e1f8c8fff153a59a11fab9777ddab60d9d023c
 SizeBytes = 14652200
+SaveAs = vc_redist.x86_vs2017.exe
 Icon = newwinsetup.ico
 SilentParameters = /install /quiet /norestart
 
@@ -17,6 +18,7 @@ RegName = {828c60b0-2de1-4d01-9534-a221878151eb}
 URLDownload = https://aka.ms/vs/15/release/vc_redist.x64.exe
 SHA1 = 747540e8001fa6f5b3a44af2a87d5c30b4183016
 SizeBytes = 15324768
+SaveAs = vc_redist.x64_vs2017.exe
 RegName = {9f38c96f-e8d2-4a17-96c1-c2ce3b79b8a9}
 
 [Section.arm]


### PR DESCRIPTION
**Problem:**
I noticed some downloaded files have the same filename. For example, `vc2008sp1run` and `vc2010sp1run` are both named `vcredist_x86.exe`. That results in the files of different versions replacing each other after download, so those files can't be kept, even if the user wants to keep them for possible future reinstall.

**Solution:**
The [`SaveAs`](https://reactos.org/wiki/RAPPS#SaveAs) fields are added so that the downloaded files are properly renamed to avoid filename collisions:
- For Microsoft Visual C++ Redistributables, a `_vs20xx` is added before the extension, following the naming convention found in `vcredist_arm_vs2015.exe`
- For .NET Framework v1.1 and v2.0, `11` or `20` is added before the extension, following the naming convention of the app name.

Not sure if this is the intended usage of `SaveAs`. It solves the problem tho :)

**Test:**
I have tested locally in applications manager by updating the local appdb. The files are saved in different filenames, and can be installed with, as expected.